### PR TITLE
Support backslashes in section names

### DIFF
--- a/InfHelper/src/Parsers/BasicTokenParser.cs
+++ b/InfHelper/src/Parsers/BasicTokenParser.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using InfHelper.Exceptions;
+using InfHelper.Models.Tokens;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using InfHelper.Exceptions;
-using InfHelper.Models.Tokens;
 
 namespace InfHelper.Parsers
 {
@@ -19,6 +19,9 @@ namespace InfHelper.Parsers
                 allTokens = new HashSet<TokenBase>(value.OrderByDescending(x => (int)x.Type));
             }
         }
+
+        public uint Length { get; private set; }
+        public uint Position { get; private set; }
 
         public ISet<TokenBase> AllowedTokens { get; set; }
         public ISet<TokenBase> IgnoredTokens { get; set; }
@@ -65,9 +68,13 @@ namespace InfHelper.Parsers
             int row = 0, col = 0;
             string line = "";
 
+            Length = (uint)formula.Length;
+            Position = 0;
+
             foreach (var c in formula)
             {
                 bool found = false;
+                Position += 1;
 
                 if (c == '\n')
                 {

--- a/InfHelper/src/Parsers/ContentParser.cs
+++ b/InfHelper/src/Parsers/ContentParser.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using InfHelper.Exceptions;
+using InfHelper.Models;
+using InfHelper.Models.Tokens;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using InfHelper.Exceptions;
-using InfHelper.Models;
-using InfHelper.Models.Tokens;
 
 namespace InfHelper.Parsers
 {
@@ -78,7 +78,8 @@ namespace InfHelper.Parsers
             {
                 new SpaceToken(),
                 new CategoryClosingToken(),
-                new LetterToken()
+                new LetterToken(),
+                new LineConcatenatorToken()
             };
         }
 
@@ -249,6 +250,13 @@ namespace InfHelper.Parsers
             {
                 case TokenType.CategoryClosing:
                     InitKeyIdParsing();
+                    break;
+                case TokenType.LineConcatenator:
+                    if (this.parser.Position == (this.parser.Length - 1))
+                    {
+                        throw new InvalidTokenException(@"'\' are not allowed as the last token in a Category");
+                    }
+                    currentCategory.Name += tokenBase.Symbol;
                     break;
                 case TokenType.Letter:
                 case TokenType.Space:

--- a/InfHelper/src/Parsers/ITokenParser.cs
+++ b/InfHelper/src/Parsers/ITokenParser.cs
@@ -1,13 +1,15 @@
-﻿using System;
+﻿using InfHelper.Models.Tokens;
+using System;
 using System.Collections.Generic;
-using InfHelper.Models.Tokens;
 
 namespace InfHelper.Parsers
 {
     public interface ITokenParser
     {
+        uint Length { get; }
+        uint Position { get; }
         ISet<TokenBase> AllowedTokens { get; set; }
-        ISet<TokenBase> AllTokens { get;}
+        ISet<TokenBase> AllTokens { get; }
         ISet<TokenBase> IgnoredTokens { get; set; }
         event EventHandler<TokenBase> InvalidTokenFound;
         event EventHandler<TokenBase> ValidTokenFound;

--- a/InfHelperTests/src/Parsers/ContentParserTests.cs
+++ b/InfHelperTests/src/Parsers/ContentParserTests.cs
@@ -1,11 +1,12 @@
-﻿using System;
+﻿using InfHelper.Exceptions;
+using InfHelper.Models;
+using InfHelper.Parsers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using InfHelper.Models;
-using InfHelper.Parsers;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace InfHelperTests.Parsers
 {
@@ -28,9 +29,34 @@ namespace InfHelperTests.Parsers
         }
 
         [TestMethod()]
+        public void CategoryWithSlashParsing()
+        {
+            string test = "[CATEGOR\\Y]";
+            var categories = new List<Category>();
+            var parser = new ContentParser();
+            parser.CategoryDiscovered += (sender, category) => categories.Add(category);
+
+            parser.Parse(test);
+
+            Assert.IsTrue(categories.Count == 1 && categories.First().Name == "CATEGOR\\Y");
+        }
+
+        [TestMethod()]
+        [ExpectedException(typeof(InvalidTokenException), @"'\' are not allowed as the last token in a Category")]
+        public void CategoryWithSlashAsLastCharacterParsing()
+        {
+            string test = "[CATEGORY\\]";
+            var categories = new List<Category>();
+            var parser = new ContentParser();
+            parser.CategoryDiscovered += (sender, category) => categories.Add(category);
+
+            parser.Parse(test);
+        }
+
+        [TestMethod()]
         public void MultipleCategoryParsing()
         {
-            int CATEGORIES_COUNT = new Random().Next(1,10);
+            int CATEGORIES_COUNT = new Random().Next(1, 10);
             var testCategories = new List<string>();
 
             for (int i = 1; i <= CATEGORIES_COUNT; i++)
@@ -39,7 +65,7 @@ namespace InfHelperTests.Parsers
             }
 
             string test = string.Join(" \n ", testCategories);
-            
+
             var categories = new List<Category>();
             var parser = new ContentParser();
             parser.CategoryDiscovered += (sender, category) => categories.Add(category);
@@ -95,7 +121,7 @@ namespace InfHelperTests.Parsers
             for (var i = 0; i < Keys_Count; i++)
             {
                 Assert.IsTrue(firstCategory.Keys[i].Id == $"Key{i}");
-                Assert.IsTrue(firstCategory.Keys[i].KeyValues.First().Value == $"Value{i}" );
+                Assert.IsTrue(firstCategory.Keys[i].KeyValues.First().Value == $"Value{i}");
             }
         }
 
@@ -193,7 +219,7 @@ namespace InfHelperTests.Parsers
             var parser = new ContentParser();
             foreach (var file in files)
             {
-                sw.Reset();                
+                sw.Reset();
                 Trace.WriteLine("Loading file content: " + file);
                 var content = File.ReadAllText(file);
                 Trace.WriteLine("Parsing file: " + file);
@@ -213,7 +239,7 @@ namespace InfHelperTests.Parsers
             parser.Parse(content);
 
             //Check categories names
-            Assert.AreEqual(categories[0].Name,"Version");
+            Assert.AreEqual(categories[0].Name, "Version");
             Assert.AreEqual(categories[1].Name, "DestinationDirs");
             Assert.AreEqual(categories[2].Name, "Manufacturer");
             Assert.AreEqual(categories[3].Name, "Standard");


### PR DESCRIPTION
As per MS rules on section names, backslashes are allowed but not as the last character.
- https://learn.microsoft.com/en-us/windows-hardware/drivers/install/general-syntax-rules-for-inf-files#-section-names