### PR TITLE
Fix comment with single quotation character in values section (e.g. 14")

### DIFF
--- a/InfHelper/src/Parsers/ContentParser.cs
+++ b/InfHelper/src/Parsers/ContentParser.cs
@@ -152,7 +152,9 @@ namespace InfHelper.Parsers
                 new SpaceToken(),
                 new WhiteSpaceToken(),
                 new InlineCommentToken(),
-                new ValueSeparatorToken()
+                new ValueSeparatorToken(),
+                new CategoryOpeningToken(),
+                new CategoryClosingToken()
             };
 
             parser.IgnoredTokens = new HashSet<TokenBase>()
@@ -201,6 +203,8 @@ namespace InfHelper.Parsers
                 case TokenType.ValueSeparator:
                 case TokenType.WhiteSpace:
                 case TokenType.Space:
+                case TokenType.CategoryOpening:
+                case TokenType.CategoryClosing:
                     keyTmpValue += tokenBase.Symbol;
                     break;
                 case TokenType.ValueMarker:

--- a/InfHelper/src/Parsers/ContentParser.cs
+++ b/InfHelper/src/Parsers/ContentParser.cs
@@ -151,12 +151,12 @@ namespace InfHelper.Parsers
                 new ValueMarkerToken(),
                 new SpaceToken(),
                 new WhiteSpaceToken(),
-                new InlineCommentToken(),
                 new ValueSeparatorToken()
             };
 
             parser.IgnoredTokens = new HashSet<TokenBase>()
             {
+                new InlineCommentToken(),
                 new LineConcatenatorToken(),
                 new EqualityToken(),
                 new CategoryOpeningToken(),
@@ -208,10 +208,6 @@ namespace InfHelper.Parsers
                 case TokenType.ValueMarker:
                     ValueParsingComplete(true);
                     InitKeyValueParsing();
-                    break;
-                case TokenType.InlineComment:
-                    ValueParsingComplete(true);
-                    InitCommentParsing(InitKeyValueParsing);
                     break;
                 default:
                     throw new InvalidTokenException("Invalid tokenBase found during comment parsing: " + tokenBase.Symbol);

--- a/InfHelper/src/Parsers/ContentParser.cs
+++ b/InfHelper/src/Parsers/ContentParser.cs
@@ -128,13 +128,13 @@ namespace InfHelper.Parsers
                 new NewLineToken(),
                 new SpaceToken(),
                 new WhiteSpaceToken(),
+                new InlineCommentToken(),
                 new ValueMarkerToken()
             };
 
             parser.IgnoredTokens = new HashSet<TokenBase>()
             {
                 new LineConcatenatorToken(),
-                new InlineCommentToken(),
                 new EqualityToken()
             };
         }
@@ -151,13 +151,13 @@ namespace InfHelper.Parsers
                 new ValueMarkerToken(),
                 new SpaceToken(),
                 new WhiteSpaceToken(),
+                new InlineCommentToken(),
                 new ValueSeparatorToken()
             };
 
             parser.IgnoredTokens = new HashSet<TokenBase>()
             {
                 new LineConcatenatorToken(),
-                new InlineCommentToken(),
                 new EqualityToken()
             };
         }
@@ -206,6 +206,10 @@ namespace InfHelper.Parsers
                 case TokenType.ValueMarker:
                     ValueParsingComplete(true);
                     InitKeyValueParsing();
+                    break;
+                case TokenType.InlineComment:
+                    ValueParsingComplete(true);
+                    InitCommentParsing(InitKeyValueParsing);
                     break;
                 default:
                     throw new InvalidTokenException("Invalid tokenBase found during comment parsing: " + tokenBase.Symbol);
@@ -339,6 +343,11 @@ namespace InfHelper.Parsers
                     break;
                 case TokenType.ValueMarker:
                     InitPureValueParsing();
+                    break;
+                case TokenType.InlineComment:
+                    ValueParsingComplete();
+                    KeyParsingComplete();
+                    InitCommentParsing(InitKeyIdParsing);
                     break;
             }
         }

--- a/InfHelper/src/Parsers/ContentParser.cs
+++ b/InfHelper/src/Parsers/ContentParser.cs
@@ -152,15 +152,15 @@ namespace InfHelper.Parsers
                 new SpaceToken(),
                 new WhiteSpaceToken(),
                 new InlineCommentToken(),
-                new ValueSeparatorToken(),
-                new CategoryOpeningToken(),
-                new CategoryClosingToken()
+                new ValueSeparatorToken()
             };
 
             parser.IgnoredTokens = new HashSet<TokenBase>()
             {
                 new LineConcatenatorToken(),
-                new EqualityToken()
+                new EqualityToken(),
+                new CategoryOpeningToken(),
+                new CategoryClosingToken()
             };
         }
 
@@ -203,8 +203,6 @@ namespace InfHelper.Parsers
                 case TokenType.ValueSeparator:
                 case TokenType.WhiteSpace:
                 case TokenType.Space:
-                case TokenType.CategoryOpening:
-                case TokenType.CategoryClosing:
                     keyTmpValue += tokenBase.Symbol;
                     break;
                 case TokenType.ValueMarker:

--- a/InfHelperTests/InfHelperTests.csproj
+++ b/InfHelperTests/InfHelperTests.csproj
@@ -123,6 +123,9 @@
     <Content Include="infs\oem98.inf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="infs\oem160.inf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="src\InfUtilTests.cs" />

--- a/InfHelperTests/infs/oem160.inf
+++ b/InfHelperTests/infs/oem160.inf
@@ -1,0 +1,1505 @@
+
+;
+; INF file for installing Realtek High Definition Audio Driver
+;
+
+[Version]
+CatalogFile=HDXRT.CAT
+Signature = "$WINDOWS NT$"
+Class=MEDIA
+ClassGuid={4d36e96c-e325-11ce-bfc1-08002be10318}
+Provider=%OrganizationName%
+DriverPackageType=PlugAndPlay
+DriverPackageDisplayName=%PackageDisplayName%
+DriverVer=04/19/2022, 6.0.9341.1
+
+[SourceDisksNames]
+222="Realtek HD Audio Installation Disk",,,
+
+[SourceDisksFiles]
+RTKVHD64.sys=222
+RTAIODAT.DAT=222
+RTEventLog.dll=222
+
+[DestinationDirs]
+DefaultDestDir=10 ; %SystemRoot%
+IntcAzAudModelCopyFiles=10,system32\drivers
+RTEventLog.CopyList  = 11
+
+[SignatureAttributes]
+RTKVHD64.sys=SignatureAttributes.DRM
+
+[SignatureAttributes.DRM]
+DRMLevel=1300
+
+[Manufacturer]
+%MfgName% = AzaliaManufacturerID, NTamd64.10.0...15063
+
+[AzaliaManufacturerID.NTamd64.10.0...15063]
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39F5 ; ThinkBook 16p NX ARH
+
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3A04 ; S170-14AMN
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3A05 ; S170-15AMN
+
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39FD ; Yoga Slim 7 Pro 16ARH7
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39F6 ; Yoga Slim 7 Pro 14ARH7
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39F3 ; IdeaPad 5 15ABA7
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39F2 ; Yoga Slim 7 Carbon 13ARB7
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA3871 ; Thinkbook-16P Gen3
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39EF ; Thinkbook-14P Gen3
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39EE ; S570-14ABA
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39EA ; YogaS770pro-14ARH
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39E5 ; Y570-15
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39E6 ; Y570P-16
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39D8 ; S170ALC-14
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39D9 ; S170ALC-15
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39DA ; S370ABA 14
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39DB ; S370ABA 15
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39DC ; S370ABA 17
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39DD ; V1-ABA-14
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39DE ; V1-ABA-15
+
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3988 ; HLXB4 ,14 Array_Mic
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39D4 ; HLXB5 ,15 Array_Mic
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3969 ; Thinkbook Gen4+ 14"
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA396D ; Thinkbook Gen4+ 16"
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3971 ; Lenovo 13W
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3967 ; Lenovo S570-16
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3970 ; Compal Lenovo NB S570Pro-14ARP
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39FA ; Compal Lenovo NB S570Pro-14ARH
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3975 ; Compal Lenovo NB C670-13
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3976 ; Compal Lenovo NB C670-13
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3949 ; S170_ADA GLS1A_14"
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA394A ; S170_ADA GLS1B_15"
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3947 ; S170-DALI-14
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3948 ; S170-DALI-15
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3936 ; S360-17
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3937 ; S360-15
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3938 ; S360-14
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA385A ; S750-14ACH-DIS
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38D3 ; L360-15ACH
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38D4 ; L360-15ACH
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39D5 ; L370-1516ARH
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39D6 ; L370-1516ARH
+
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39E2
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39E4
+
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA3858 ; YogaC750-14ACZ
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA3870 ; Ideapad Yoga C770 AMD Rembradt
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA3856 ; S760-14
+;"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0230&SUBSYS_17AA3859 ; S360-14
+;"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0230&SUBSYS_17AA385A ; S360-15
+;"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0230&SUBSYS_17AA385B ; S360-17
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38D5 ; S550-15 ALC
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0274&SUBSYS_17AA373B
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0235&SUBSYS_17AA374D
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0235&SUBSYS_17AA374E
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0235&SUBSYS_17AA373E
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0235&SUBSYS_17AA374C
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38CF ; Thinkbook 14P
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA384C ; Thinkbook 16P
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38CA ; S560-16
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3957
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA3841 ; Y560-15
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA3845 ; Y560-17
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA3846 ; Y560P-16
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA3847 ; Y760-16
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA3859 ; Y760S???A+N)
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA389A ;S150-14AST change CPU
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA389B ;S150-14AST change CPU
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38BB
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38BC
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38BD
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38BE
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38BF
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA509A
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5094
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5095
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5096
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA3844
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA383A
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA384F
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA3900
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0230&SUBSYS_17AA384D
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0230&SUBSYS_17AA384E
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3930
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3931
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0230&SUBSYS_17AA383F
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0230&SUBSYS_17AA3840
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0230&SUBSYS_17AA3841
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA392D
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA392E
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA392F
+
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA3839
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA507F
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5080
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5081
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5082
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5083
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5084
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3869
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0230&SUBSYS_17AA383C
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0230&SUBSYS_17AA383D
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0230&SUBSYS_17AA383E
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA507E
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5085
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA380D
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA386C
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38AD
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38B3
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3884
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA388D
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA388E
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA388F
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3890
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3891
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3892
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38C4
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38C5
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38C8
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38C9
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA387D
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA389C
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA389D
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA389E
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0230&SUBSYS_17AA3851
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA387F
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA386D
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38B9
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA396C
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA396F
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3972
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3973
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38BA
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38A1
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38C0
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA395E
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38C1
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38A2
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3882
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3887
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0285&SUBSYS_17AA380C
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0285&SUBSYS_17AA380E
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3899
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA384C
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA381D
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA381F
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38A5
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38AF
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38D0
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA38D1
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5091
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5092
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5097
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5098
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA509C
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA509D
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0285&SUBSYS_17AA7403
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5125
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5126
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA5127
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA001A
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA50A2
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA50A3
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA50A4
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA50A5
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA22F1
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA22F2
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0287&SUBSYS_17AA22F3
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA50AB
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA50AE
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA50AF
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA50B1
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA50B3
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA50B4
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA50B5
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA50B6
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA50B7
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA50B8
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA50B9
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA22FF
+"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA2300
+
+
+[IntcAzAudModelCopyFiles]
+RTKVHD64.sys
+RTAIODAT.DAT
+
+[RTEventLog.CopyList]
+RtEventLog.dll
+
+;;================= Windows 64 ====================
+[IntcAzAudModel.NTamd64]
+Include=ks.inf,wdmaudio.inf
+Needs=KS.Registration,WDMAUDIO.Registration
+CopyFiles = IntcAzAudModelCopyFiles, RTEventLog.CopyList
+AddReg    = RtHdaBaseAddReg
+AddProperty  = OEMCustomBranding.AddProperty
+
+[IntcAzAudModel.NTamd64.HW]
+AddReg=HdAudSecurity.AddReg
+
+[IntcAzAudModel.NTamd64.Services]
+AddService = IntcAzAudAddService, 0x00000002, IntcAzAudServiceInstall, IntcAzAudServiceEventLog
+
+[IntcAzAudServiceInstall]
+DisplayName   = "Service for Realtek HD Audio (WDM)"
+ServiceType   = 1
+StartType     = 3
+ErrorControl  = 1
+ServiceBinary = %10%\system32\drivers\RTKVHD64.sys
+
+[IntcAzAudServiceEventLog]
+AddReg=AddRegCommonEventLogSection
+
+[AddRegCommonEventLogSection]
+HKR,,"EventMessageFile",0x00020000,"%%SystemRoot%%\System32\RtEventLog.dll;%%12%%\RTKVHD64.sys"
+HKR,,"TypesSupported",0x00010001,0x00000007
+
+
+[OEMCustomBranding.AddProperty]
+;; TODO: use a resource dll instead or just remove it
+;;DeviceBrandingIcon,,,,"%%SystemRoot%%\System32\RtPgEx64.dll,-200"
+DeviceVendorWebSite,,,,"http://www.realtek.com/" ; Place your URL here
+
+[HdAudSecurity.AddReg]
+; FILE_DEVICE_SOUND
+HKR,,DeviceType,0x10001,0x0000001D
+; SDDL_DEVOBJ_SYS_ALL_ADM_RWX_WORLD_RWX_RES_RWX HKR,,Security,,"D:P(A;;GA;;;SY)(A;;GRGWGX;;;BA)(A;;GRGWGX;;;WD)(A;;GRGWGX;;;RC)"
+
+
+[RtHdaBaseAddReg]
+HKR,,AssociatedFilters,,"wdmaud,swmidi,redbook"
+HKR,,Driver,,RTKVHD64.sys
+HKR,Settings,COINSTALLER_NEED_ADD_CPL_RUNKEY,0x00010001,1
+HKR,Settings,DECOUPLE,0x00010001,1
+;For driver reference
+HKR,Settings,DCH_HAP,0x00010001,1
+HKR,Settings,HAPACPI,0x00010001,1
+
+HKR, DispatchSettings, UsePositionLock, 3, 01, 00, 00, 00
+
+HKR,PowerSettings,ConservationIdleTime,1,00,00,00,0     ; Not doing idle power management when on battery
+HKR,PowerSettings,PerformanceIdleTime,1,00,00,00,00     ; Not doing idle power management when on AC power
+HKR,PowerSettings,IdlePowerState,1,03,00,00,00          ; go to D3 for idle power management
+
+HKR,Settings,EQ_AGC_CONTROL,0x00010001,0
+
+HKR,Drivers,SubClasses,,"wave,midi,mixer,aux"
+
+HKR,Drivers\wave\wdmaud.drv,Driver,,wdmaud.drv
+HKR,Drivers\midi\wdmaud.drv,Driver,,wdmaud.drv
+HKR,Drivers\mixer\wdmaud.drv,Driver,,wdmaud.drv
+HKR,Drivers\aux\wdmaud.drv,Driver,,wdmaud.drv
+
+HKR,Drivers\wave\wdmaud.drv,Description,,%IntcAzAudioDeviceDescription%
+HKR,Drivers\midi\wdmaud.drv,Description,,%IntcAzAudioDeviceDescription%
+HKR,Drivers\mixer\wdmaud.drv,Description,,%IntcAzAudioDeviceDescription%
+HKR,Drivers\aux\wdmaud.drv,Description,,%IntcAzAudioDeviceDescription%
+
+HKR,,SetupPreferredAudioDevices,3,01,00,00,00
+
+HKR,InterfaceSetting\FriendlyName,RearLineOutWave,,%RearLineOutWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineOutTopo,,%RearLineOutTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineOutWave2,,%PrimaryLineOutWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,PrimaryLineOutTopo,,%PrimaryLineOutTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineOutWave3,,%SingleLineOutWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,SingleLineOutTopo,,%SingleLineOutTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,SecondaryLineOutWave,,%SecondaryLineOutWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,SecondaryLineOutTopo,,%SecondaryLineOutTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontPanelHeadphoneWave,,%FrontPanelHeadphoneWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontPanelHeadphoneTopo,,%FrontPanelHeadphoneTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtSpdifWave,,%RtSpdifWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtSpdifTopo,,%RtSpdifTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtSpdifHDMIWave,,%RtSpdifHDMIWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtSpdifHDMITopo,,%RtSpdifHDMITopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtSpdifRCAWave,,%RtSpdifRCAWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtSpdifRCATopo,,%RtSpdifRCATopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtSpdifOptWave,,%RtSpdifOptWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtSpdifOptTopo,,%RtSpdifOptTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,BTBPOutWave,,"Realtek HDA Bluetooth Bypass Output"
+HKR,InterfaceSetting\FriendlyName,BTBPOutTopo,,"Realtek HDA Bluetooth Bypass Output Mixer"
+HKR,InterfaceSetting\FriendlyName,BTBPInWave,,"Realtek HDA Bluetooth Bypass Iutput"
+HKR,InterfaceSetting\FriendlyName,BTBPInTopo,,"Realtek HDA Bluetooth Bypass Iutput Mixer"
+HKR,InterfaceSetting\FriendlyName,RearLineOutWaveSST,,"Realtek HD Audio output with SST"
+HKR,InterfaceSetting\FriendlyName,RearLineOutTopoSST,,"Realtek HD Audio output mixer with SST"
+HKR,InterfaceSetting\FriendlyName,RearLineOutWaveSST2,,"Realtek HDA Primary output with SST"
+HKR,InterfaceSetting\FriendlyName,RearLineOutTopoSST2,,"Realtek HDA Primary output mixer with SST"
+HKR,InterfaceSetting\FriendlyName,RearLineOutWaveSST3,,"Realtek HD Audio 2nd output with SST"
+HKR,InterfaceSetting\FriendlyName,RearLineOutTopoSST3,,"Realtek HD Audio 2nd output mixer with SST"
+HKR,InterfaceSetting\FriendlyName,RearLineOutWaveDock,,"Realtek HD Audio dock/base output"
+HKR,InterfaceSetting\FriendlyName,RearLineOutTopoDock,,"Realtek HD Audio dock/base output mixer"
+HKR,InterfaceSetting\FriendlyName,RearLineOutWaveHAP,,"Realtek HD Audio output with HAP"
+HKR,InterfaceSetting\FriendlyName,RearLineOutTopoHAP,,"Realtek HD Audio output mixer with HAP"
+HKR,InterfaceSetting,RearLineOutTopoHAP,0x10000,"SysFx","OEMSettingsOverride"
+HKR,InterfaceSetting\FriendlyName,RearLineOutWaveHAP2,,"Realtek HDA Primary output with HAP"
+HKR,InterfaceSetting\FriendlyName,RearLineOutTopoHAP2,,"Realtek HDA Primary output mixer with HAP"
+HKR,InterfaceSetting,RearLineOutTopoHAP2,0x10000,"SysFx","OEMSettingsOverride"
+HKR,InterfaceSetting\FriendlyName,RearLineOutWaveHAP3,,"Realtek HD Audio 2nd output with HAP"
+HKR,InterfaceSetting\FriendlyName,RearLineOutTopoHAP3,,"Realtek HD Audio 2nd output mixer with HAP"
+HKR,InterfaceSetting,RearLineOutTopoHAP3,0x10000,"SysFx","OEMSettingsOverride"
+
+HKR,InterfaceSetting\FriendlyName,RearLineInWave3,,%SingleLineInWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,SingleLineInTopo,,%SingleLineInTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,SecondaryLineInWave,,%SecondaryLineInWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,SecondaryLineInTopo,,%SecondaryLineInTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,PrimaryLineInWave,,%PrimaryLineInWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,PrimaryLineInTopo,,%PrimaryLineInTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,DigitalInputWave,,%DigitalInputWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,DigitalInputTopo,,%DigitalInputTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,HPRearCaptureWave,,%HPRearCaptureWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,HPRearCaptureTopo,,%HPRearCaptureTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,HPCPCCaptureWave,,%HPCPCCaptureWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,HPCPCCaptureTopo,,%HPCPCCaptureTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInBlackWave,,%RearLineInBlackWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInBlackTopo,,%RearLineInBlackTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInGreyWave,,%RearLineInGreyWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInGreyTopo,,%RearLineInGreyTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInBlueWave,,%RearLineInBlueWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInBlueTopo,,%RearLineInBlueTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInGreenWave,,%RearLineInGreenWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInGreenTopo,,%RearLineInGreenTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInRedWave,,%RearLineInRedWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInRedTopo,,%RearLineInRedTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInOrangeWave,,%RearLineInOrangeWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInOrangeTopo,,%RearLineInOrangeTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInYellowWave,,%RearLineInYellowWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInYellowTopo,,%RearLineInYellowTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInPurpleWave,,%RearLineInPurpleWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInPurpleTopo,,%RearLineInPurpleTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInPinkWave,,%RearLineInPinkWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInPinkTopo,,%RearLineInPinkTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInGoldenWave,,%RearLineInGoldenWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInGoldenTopo,,%RearLineInGoldenTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInSilverWave,,%RearLineInSilverWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInSilverTopo,,%RearLineInSilverTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInWhiteWave,,%RearLineInWhiteWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearLineInWhiteTopo,,%RearLineInWhiteTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInBlackWave,,%RearMicInBlackWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInBlackTopo,,%RearMicInBlackTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInGreyWave,,%RearMicInGreyWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInGreyTopo,,%RearMicInGreyTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInBlueWave,,%RearMicInBlueWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInBlueTopo,,%RearMicInBlueTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInGreenWave,,%RearMicInGreenWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInGreenTopo,,%RearMicInGreenTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInRedWave,,%RearMicInRedWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInRedTopo,,%RearMicInRedTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInOrangeWave,,%RearMicInOrangeWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInOrangeTopo,,%RearMicInOrangeTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInYellowWave,,%RearMicInYellowWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInYellowTopo,,%RearMicInYellowTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInPurpleWave,,%RearMicInPurpleWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInPurpleTopo,,%RearMicInPurpleTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInPinkWave,,%RearMicInPinkWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInPinkTopo,,%RearMicInPinkTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInGoldenWave,,%RearMicInGoldenWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInGoldenTopo,,%RearMicInGoldenTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInSilverWave,,%RearMicInSilverWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInSilverTopo,,%RearMicInSilverTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInWhiteWave,,%RearMicInWhiteWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RearMicInWhiteTopo,,%RearMicInWhiteTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInBlackWave,,%FrontLineInBlackWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInBlackTopo,,%FrontLineInBlackTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInGreyWave,,%FrontLineInGreyWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInGreyTopo,,%FrontLineInGreyTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInBlueWave,,%FrontLineInBlueWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInBlueTopo,,%FrontLineInBlueTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInGreenWave,,%FrontLineInGreenWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInGreenTopo,,%FrontLineInGreenTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInRedWave,,%FrontLineInRedWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInRedTopo,,%FrontLineInRedTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInOrangeWave,,%FrontLineInOrangeWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInOrangeTopo,,%FrontLineInOrangeTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInYellowWave,,%FrontLineInYellowWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInYellowTopo,,%FrontLineInYellowTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInPurpleWave,,%FrontLineInPurpleWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInPurpleTopo,,%FrontLineInPurpleTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInPinkWave,,%FrontLineInPinkWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInPinkTopo,,%FrontLineInPinkTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInGoldenWave,,%FrontLineInGoldenWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInGoldenTopo,,%FrontLineInGoldenTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInSilverWave,,%FrontLineInSilverWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInSilverTopo,,%FrontLineInSilverTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInWhiteWave,,%FrontLineInWhiteWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontLineInWhiteTopo,,%FrontLineInWhiteTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInBlackWave,,%FrontMicInBlackWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInBlackTopo,,%FrontMicInBlackTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInGreyWave,,%FrontMicInGreyWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInGreyTopo,,%FrontMicInGreyTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInBlueWave,,%FrontMicInBlueWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInBlueTopo,,%FrontMicInBlueTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInGreenWave,,%FrontMicInGreenWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInGreenTopo,,%FrontMicInGreenTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInRedWave,,%FrontMicInRedWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInRedTopo,,%FrontMicInRedTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInOrangeWave,,%FrontMicInOrangeWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInOrangeTopo,,%FrontMicInOrangeTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInYellowWave,,%FrontMicInYellowWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInYellowTopo,,%FrontMicInYellowTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInPurpleWave,,%FrontMicInPurpleWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInPurpleTopo,,%FrontMicInPurpleTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInPinkWave,,%FrontMicInPinkWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInPinkTopo,,%FrontMicInPinkTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInGoldenWave,,%FrontMicInGoldenWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInGoldenTopo,,%FrontMicInGoldenTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInSilverWave,,%FrontMicInSilverWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInSilverTopo,,%FrontMicInSilverTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInWhiteWave,,%FrontMicInWhiteWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,FrontMicInWhiteTopo,,%FrontMicInWhiteTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtStereoMixWave,,%RtStereoMixWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtStereoMixTopo,,%RtStereoMixTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtMicInWave,,"Realtek HD Audio Mic input"
+HKR,InterfaceSetting\FriendlyName,RtMicInTopo,,"Realtek HD Audio Mic input mixer"
+HKR,InterfaceSetting\FriendlyName,RtMicInSSTWave,,"Realtek HD Audio Mic input with SST"
+HKR,InterfaceSetting\FriendlyName,RtMicInSSTTopo,,"Realtek HD Audio Mic input mixer with SST"
+HKR,InterfaceSetting\FriendlyName,RtLineInWave,,%RtLineInWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtLineInTopo,,%RtLineInTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtCDInWave,,%RtCDInWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtCDInTopo,,%RtCDInTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtAuxInWave,,%RtAuxInWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtAuxInTopo,,%RtAuxInTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtFrontMicInWave,,%RtFrontMicInWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtFrontMicInTopo,,%RtFrontMicInTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtFrontLineInWave,,%RtFrontLineInWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtFrontLineInTopo,,%RtFrontLineInTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,DigitalMICWave,,%DigitalMICWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,DigitalMICTopo,,%DigitalMICTopoDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtMicArWave,,%RtMicArWaveDeviceName%
+HKR,InterfaceSetting\FriendlyName,RtMicArTopo,,%RtMicArTopoDeviceName%
+
+HKR,InterfaceSetting,RearLineOutTopo,0x10000,"OEMSettingsOverride"
+HKR,InterfaceSetting,PrimaryLineOutTopo,0x10000,"OEMSettingsOverride"
+HKR,InterfaceSetting,SingleLineOutTopo,0x10000,"OEMSettingsOverride"
+HKR,InterfaceSetting,SecondaryLineOutTopo,0x10000,"OEMSettingsOverride"
+HKR,InterfaceSetting,FrontPanelHeadphoneTopo,0x10000,"OEMSettingsOverride"
+HKR,InterfaceSetting,RtSpdifTopo,0x10000,"OEMSPDIFSettingsOverride"
+HKR,InterfaceSetting,RtSpdifHDMITopo,0x10000,"OEMSPDIFSettingsOverride"
+HKR,InterfaceSetting,RtSpdifRCATopo,0x10000,"OEMSPDIFSettingsOverride"
+HKR,InterfaceSetting,RtSpdifOptTopo,0x10000,"OEMSPDIFSettingsOverride"
+HKR,InterfaceSetting,BTBPOutTopo,0x10000,"RTHDAProperties"
+HKR,InterfaceSetting,RearLineOutTopoSST,0x10000,"OEMSettingsOverride"
+HKR,InterfaceSetting,RearLineOutTopoSST2,0x10000,"OEMSettingsOverride"
+HKR,InterfaceSetting,RearLineOutTopoSST3,0x10000,"OEMSettingsOverride"
+HKR,InterfaceSetting,RearLineOutTopoDock,0x10000,"OEMSettingsOverride"
+
+HKR,InterfaceSetting,SingleLineInTopo,0x10000,"RTHDAProperties"
+HKR,InterfaceSetting,RtLineInTopo,0x10000,"RTHDAProperties"
+HKR,InterfaceSetting,DigitalInputTopo,0x10000,"RTHDAProperties"
+HKR,InterfaceSetting,RearMicInBlackTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,RearMicInGreyTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,RearMicInBlueTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,RearMicInGreenTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,RearMicInRedTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,RearMicInOrangeTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,RearMicInYellowTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,RearMicInPurpleTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,RearMicInPinkTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,RearMicInGoldenTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,RearMicInSilverTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,RearMicInWhiteTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,FrontMicInBlackTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,FrontMicInGreyTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,FrontMicInBlueTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,FrontMicInGreenTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,FrontMicInRedTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,FrontMicInOrangeTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,FrontMicInYellowTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,FrontMicInPurpleTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,FrontMicInPinkTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,FrontMicInGoldenTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,FrontMicInSilverTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,FrontMicInWhiteTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,BTBPInTopo,0x10000,"RTHDAProperties"
+HKR,InterfaceSetting,RtMicInTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,RtFrontMicInTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,DigitalMICTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,RtMicArTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,RtMicInSSTTopo,0x10000,"OEMMicInSettingsOverride"
+HKR,InterfaceSetting,RtStereoMixTopo,0x10000,"RTHDAProperties"
+
+HKR,InterfaceSetting\OEMSettingsOverride\EP\0, "RtEPAssociation",,%KSNODETYPE_ANY%
+HKR,InterfaceSetting\OEMSettingsOverride\EP\0, %PKEY_AudioEngine_OEMFormat%, %REG_BINARY%, 41,00,C8,70,28,00,00,00,FE,FF,02,00,80,BB,00,00,00,DC,05,00,08,00,20,00,16,00,18,00,03,00,00,00,01,00,00,00,00,00,10,00,80,00,00,AA,00,38,9B,71
+HKR,InterfaceSetting\OEMSettingsOverride\EP\0, %PKEY_AudioEndpoint_Supports_EventDriven_Mode%,0x00010001,0x1
+HKR,InterfaceSetting\RTHDAProperties\EP\0,"RtEPAssociation",,%KSNODETYPE_ANY%
+HKR,InterfaceSetting\RTHDAProperties\EP\0,%PKEY_AudioEndpoint_Supports_EventDriven_Mode%,0x00010001,0x1
+HKR,InterfaceSetting\OEMSPDIFSettingsOverride\EP\0, "RtEPAssociation",,%KSNODETYPE_ANY%
+HKR,InterfaceSetting\OEMSPDIFSettingsOverride\EP\0, %PKEY_AudioEngine_OEMFormat%, %REG_BINARY%, 41,00,C8,70,28,00,00,00,FE,FF,02,00,80,BB,00,00,00,EE,02,00,04,00,10,00,16,00,10,00,03,00,00,00,01,00,00,00,00,00,10,00,80,00,00,AA,00,38,9B,71
+HKR,InterfaceSetting\OEMSPDIFSettingsOverride\EP\0, %PKEY_AudioEndpoint_Supports_EventDriven_Mode%,0x00010001,0x1
+HKR,InterfaceSetting\SysRecFx\EP\0,"RtEPAssociation",,%KSNODETYPE_ANY%
+HKR,InterfaceSetting\SysRecFx\EP\0,%PKEY_AudioEndpoint_Supports_EventDriven_Mode%,0x00010001,0x1
+HKR,InterfaceSetting\OEMMicInSettingsOverride\EP\0, "RtEPAssociation",,%KSNODETYPE_ANY%
+HKR,InterfaceSetting\OEMMicInSettingsOverride\EP\0, %PKEY_AudioEngine_OEMFormat%, %REG_BINARY%, 41,00,C8,70,28,00,00,00,FE,FF,02,00,80,BB,00,00,00,EE,02,00,04,00,10,00,16,00,10,00,03,00,00,00,01,00,00,00,00,00,10,00,80,00,00,AA,00,38,9B,71
+HKR,InterfaceSetting\OEMMicInSettingsOverride\EP\0, %PKEY_AudioEndpoint_Supports_EventDriven_Mode%,0x00010001,0x1
+
+HKR,SSTPPCfg\{7111001F-D35F-44D9-81D2-7AC685BED3D7}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{7111001F-D35F-44D9-81D2-7AC685BED3D7}\SPK\EFX,Position,0x10001,9
+HKR,SSTPPCfg\{7111001F-D35F-44D9-81D2-7AC685BED3D7}\SPK\EFX,IsMandatory,0x10001,1
+
+HKR,SSTPPCfg\{7AA4DB02-6B41-4BC3-A712-80A2DDE29E11}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{7AA4DB02-6B41-4BC3-A712-80A2DDE29E11}\SPK\EFX,Position,0x10001,9
+HKR,SSTPPCfg\{7AA4DB02-6B41-4BC3-A712-80A2DDE29E11}\SPK\EFX,IsMandatory,0x10001,1
+
+HKR,SSTPPCfg\{78819325-A976-4316-B2BA-49285D83C725}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{78819325-A976-4316-B2BA-49285D83C725}\SPK\EFX,Position,0x10001,9
+HKR,SSTPPCfg\{78819325-A976-4316-B2BA-49285D83C725}\SPK\EFX,IsMandatory,0x10001,1
+
+
+HKR,SSTPPCfg\{E1284052-8664-4FE4-A353-3878F72704C3}\HP\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{E1284052-8664-4FE4-A353-3878F72704C3}\HP\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{E1284052-8664-4FE4-A353-3878F72704C3}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{E1284052-8664-4FE4-A353-3878F72704C3}\SPK\EFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{D9C95249-EDFC-4046-96EC-15D2EB12C74E}\HP\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{D9C95249-EDFC-4046-96EC-15D2EB12C74E}\HP\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{D9C95249-EDFC-4046-96EC-15D2EB12C74E}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{D9C95249-EDFC-4046-96EC-15D2EB12C74E}\SPK\EFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{B489C2DE-0F96-42E1-8A2D-C25B5091EE49}\HP\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{B489C2DE-0F96-42E1-8A2D-C25B5091EE49}\HP\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{B489C2DE-0F96-42E1-8A2D-C25B5091EE49}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{B489C2DE-0F96-42E1-8A2D-C25B5091EE49}\SPK\EFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{E0E018A8-3550-4B54-A8D0-A8E05D0FCBA2}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{E0E018A8-3550-4B54-A8D0-A8E05D0FCBA2}\HP\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{E0E018A8-3550-4B54-A8D0-A8E05D0FCBA2}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{E0E018A8-3550-4B54-A8D0-A8E05D0FCBA2}\SPK\MFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{202BADB5-8870-4290-B536-F2380C63F55D}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{202BADB5-8870-4290-B536-F2380C63F55D}\SPK\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{202BADB5-8870-4290-B536-F2380C63F55D}\SPK\EFX,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0
+HKR,SSTPPCfg\{F1C69181-329A-45F0-8EEF-D8BDDF81E036}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{F1C69181-329A-45F0-8EEF-D8BDDF81E036}\SPK\EFX,Position,0x10001,2
+
+HKR,SSTPPCfg\{7AEA5E24-E5E9-4D6D-B88F-B505C1ACAB11}\MIC\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{7AEA5E24-E5E9-4D6D-B88F-B505C1ACAB11}\MIC\MFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{7C708106-3AFF-40FE-88BE-8C999B3F7445}\MIC\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{7C708106-3AFF-40FE-88BE-8C999B3F7445}\MIC\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{7C708106-3AFF-40FE-88BE-8C999B3F7445}\MIC\MFX,0,1,3,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, \
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,ff,7f,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, \
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,ff,7f,0,0,0,0,0,0,0,0,0,0,0,0, \
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,0,2,0,96,0,88,0,88,0,88,0,88,0,88,0,1,0,f7,ff,0,0,0,60,ff,7f,29,7c,fb,ff,f8,ff,fb,ff,f5,ff,31,0,f2,ff,0,0,2,0,f8,ff,0,10,0,0,27,0,10,0,0,0,0,0,0,0,0,0,0,0,0,0,f8,ff,fc,ff,fe,ff,fe, \
+ff,ff,ff,f1,ff,cd,2c,66,66,cd,2c,9a,79,0,70,0,40,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, \
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, \
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, \
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, \
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,0,0,0,0,0,5a,0,2d,0,ec,ff,0,10,0,0,0,30,0,8,33,73,0,0,0,0,0,0,0,8,0,8,aa,6a,cd,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, \
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, \
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, \
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, \
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,5,0,0,0,0,0,0,0,0,0
+
+HKR,SSTPPCfg\{B3573EFF-6441-4A75-91F7-4281EEC4597D}\MIC\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{B3573EFF-6441-4A75-91F7-4281EEC4597D}\MIC\MFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{F3578986-4400-4ADF-AE7E-CD433CD3F26E}\MIC\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{F3578986-4400-4ADF-AE7E-CD433CD3F26E}\MIC\MFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{C75061F3-F2B2-4DCC-8F9F-82ABB4131E66}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{C75061F3-F2B2-4DCC-8F9F-82ABB4131E66}\SPK\EFX,Position,0x10001,9
+
+HKR,SSTPPCfg\{29606035-3BF7-4E96-A613-CA8C90022652}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{29606035-3BF7-4E96-A613-CA8C90022652}\SPK\EFX,Position,0x10001,9
+
+HKR,SSTPPCfg\{9A44A769-1A51-464A-A54B-1A4084BF370B}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{9A44A769-1A51-464A-A54B-1A4084BF370B}\SPK\EFX,Position,0x10001,9
+
+HKR,SSTPPCfg\{149C23DD-6990-4F1F-8E16-03B14C21A731}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{149C23DD-6990-4F1F-8E16-03B14C21A731}\SPK\EFX,Position,0x10001,9
+
+HKR,SSTPPCfg\{A07EECE7-8F01-4ECD-8BDE-3E4DE8A55F81}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{A07EECE7-8F01-4ECD-8BDE-3E4DE8A55F81}\SPK\EFX,Position,0x10001,9
+
+HKR,SSTPPCfg\{D46F9D72-81A4-47FD-B301-8E39D17C0981}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{D46F9D72-81A4-47FD-B301-8E39D17C0981}\SPK\EFX,Position,0x10001,1
+;HKR,SSTPPCfg\{D46F9D72-81A4-47FD-B301-8E39D17C0981}\HP\EFX,Enabled,0x10001,1
+;HKR,SSTPPCfg\{D46F9D72-81A4-47FD-B301-8E39D17C0981}\HP\EFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{347297C3-A6D5-40DB-8120-ACE66BABF491}\MIC\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{347297C3-A6D5-40DB-8120-ACE66BABF491}\MIC\MFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{849F0D73-1678-4D57-8C78-61C548253993}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{849F0D73-1678-4D57-8C78-61C548253993}\SPK\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{849F0D73-1678-4D57-8C78-61C548253993}\HP\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{849F0D73-1678-4D57-8C78-61C548253993}\HP\EFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{88373A01-16A5-469D-A39A-BDEB594178B8}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{88373A01-16A5-469D-A39A-BDEB594178B8}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{88373A01-16A5-469D-A39A-BDEB594178B8}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{88373A01-16A5-469D-A39A-BDEB594178B8}\HP\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{52983D04-2414-88B4-A2A2-C1397E13B022}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{52983D04-2414-88B4-A2A2-C1397E13B022}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{52983D04-2414-88B4-A2A2-C1397E13B022}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{52983D04-2414-88B4-A2A2-C1397E13B022}\HP\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{FAACC8CC-B365-4964-B4B8-BD4DEB18D922}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{FAACC8CC-B365-4964-B4B8-BD4DEB18D922}\SPK\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{FAACC8CC-B365-4964-B4B8-BD4DEB18D922}\HP\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{FAACC8CC-B365-4964-B4B8-BD4DEB18D922}\HP\EFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{FCB01F86-5FFF-43AB-91F8-E6AD8629B6D6}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{FCB01F86-5FFF-43AB-91F8-E6AD8629B6D6}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{FCB01F86-5FFF-43AB-91F8-E6AD8629B6D6}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{FCB01F86-5FFF-43AB-91F8-E6AD8629B6D6}\HP\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{FD80E302-E902-400F-96C2-27A548318B54}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{FD80E302-E902-400F-96C2-27A548318B54}\SPK\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{FD80E302-E902-400F-96C2-27A548318B54}\HP\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{FD80E302-E902-400F-96C2-27A548318B54}\HP\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{FE2E23E3-E8B2-4C33-9860-F4B90A65C91C}\MIC\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{FE2E23E3-E8B2-4C33-9860-F4B90A65C91C}\MIC\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{FF8D87AA-4E36-41AA-BB5B-65DED906B148}\MIC\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{FF8D87AA-4E36-41AA-BB5B-65DED906B148}\MIC\EFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{7159BBD2-EF07-48E8-BDB7-17EE17423C14}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{7159BBD2-EF07-48E8-BDB7-17EE17423C14}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{7159BBD2-EF07-48E8-BDB7-17EE17423C14}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{7159BBD2-EF07-48E8-BDB7-17EE17423C14}\HP\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{6522C274-B55B-41D7-8363-49CFE2E10580}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{6522C274-B55B-41D7-8363-49CFE2E10580}\SPK\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{6522C274-B55B-41D7-8363-49CFE2E10580}\HP\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{6522C274-B55B-41D7-8363-49CFE2E10580}\HP\EFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{2F20FF4C-587D-4EA5-BD72-F246351DEFE6}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{2F20FF4C-587D-4EA5-BD72-F246351DEFE6}\SPK\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{2F20FF4C-587D-4EA5-BD72-F246351DEFE6}\HP\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{2F20FF4C-587D-4EA5-BD72-F246351DEFE6}\HP\EFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{9DC26903-A3A8-4A30-8839-A77B6F4E5964}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{9DC26903-A3A8-4A30-8839-A77B6F4E5964}\SPK\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{9DC26903-A3A8-4A30-8839-A77B6F4E5964}\HP\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{9DC26903-A3A8-4A30-8839-A77B6F4E5964}\HP\EFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{F7922237-511F-4203-A780-2C2CE0A13AF2}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{F7922237-511F-4203-A780-2C2CE0A13AF2}\SPK\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{F7922237-511F-4203-A780-2C2CE0A13AF2}\HP\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{F7922237-511F-4203-A780-2C2CE0A13AF2}\HP\EFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{56A9EA76-3745-4CC0-815C-A621FAA8C9CB}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{56A9EA76-3745-4CC0-815C-A621FAA8C9CB}\SPK\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{56A9EA76-3745-4CC0-815C-A621FAA8C9CB}\HP\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{56A9EA76-3745-4CC0-815C-A621FAA8C9CB}\HP\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{D11B4F61-42FA-43BB-997C-8D2B026D11C8}\SPK\SFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{D11B4F61-42FA-43BB-997C-8D2B026D11C8}\SPK\SFX,Position,0x10001,1
+HKR,SSTPPCfg\{D11B4F61-42FA-43BB-997C-8D2B026D11C8}\HP\SFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{D11B4F61-42FA-43BB-997C-8D2B026D11C8}\HP\SFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{63D841D9-29C2-4251-8969-7628529C52BE}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{63D841D9-29C2-4251-8969-7628529C52BE}\SPK\EFX,Position,0x10001,8
+
+HKR,SSTPPCfg\{5646C4AB-E8E8-4EEF-A8D7-1834D112FBAD}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{5646C4AB-E8E8-4EEF-A8D7-1834D112FBAD}\SPK\MFX,Position,0x10001,1
+
+;Dolby v1.3.1 High Resolution
+HKR,SSTPPCfg\{2CEA7CB6-7F35-4C1B-B7E3-054F6C479955}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{2CEA7CB6-7F35-4C1B-B7E3-054F6C479955}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{2CEA7CB6-7F35-4C1B-B7E3-054F6C479955}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{2CEA7CB6-7F35-4C1B-B7E3-054F6C479955}\HP\MFX,Position,0x10001,1
+;Dolby v1.3.1 lite 
+HKR,SSTPPCfg\{01FD7450-263C-43B5-ADCC-CBCD61975F89}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{01FD7450-263C-43B5-ADCC-CBCD61975F89}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{01FD7450-263C-43B5-ADCC-CBCD61975F89}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{01FD7450-263C-43B5-ADCC-CBCD61975F89}\HP\MFX,Position,0x10001,1
+;REALTEK_SPEAKER_PROTECTION
+HKR,SSTPPCfg\{1C8E9AC4-BEA0-40EF-B6EE-BC28D5E138DB}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{1C8E9AC4-BEA0-40EF-B6EE-BC28D5E138DB}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{1C8E9AC4-BEA0-40EF-B6EE-BC28D5E138DB}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{1C8E9AC4-BEA0-40EF-B6EE-BC28D5E138DB}\HP\MFX,Position,0x10001,1
+;DOLBY_DAX3
+HKR,SSTPPCfg\{CFE115BD-8AEA-40BC-A764-AD9C18FEE730}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{CFE115BD-8AEA-40BC-A764-AD9C18FEE730}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{CFE115BD-8AEA-40BC-A764-AD9C18FEE730}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{CFE115BD-8AEA-40BC-A764-AD9C18FEE730}\HP\MFX,Position,0x10001,1
+;SOUNDRESEARCH
+HKR,SSTPPCfg\{2C7DB080-64DF-428C-9A56-9EBAB64FCAA2}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{2C7DB080-64DF-428C-9A56-9EBAB64FCAA2}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{2C7DB080-64DF-428C-9A56-9EBAB64FCAA2}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{2C7DB080-64DF-428C-9A56-9EBAB64FCAA2}\HP\MFX,Position,0x10001,1
+;WAVES
+HKR,SSTPPCfg\{BA0180D4-40A4-47C3-97D7-9CEBC06AACE1}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{BA0180D4-40A4-47C3-97D7-9CEBC06AACE1}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{BA0180D4-40A4-47C3-97D7-9CEBC06AACE1}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{BA0180D4-40A4-47C3-97D7-9CEBC06AACE1}\HP\MFX,Position,0x10001,1
+;DTS_EFX
+HKR,SSTPPCfg\{CEFAB025-8A3F-4409-AD42-52CE4210D85E}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{CEFAB025-8A3F-4409-AD42-52CE4210D85E}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{CEFAB025-8A3F-4409-AD42-52CE4210D85E}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{CEFAB025-8A3F-4409-AD42-52CE4210D85E}\HP\MFX,Position,0x10001,1
+;Nahimic
+HKR,SSTPPCfg\{EA2AD408-DAE4-4C92-BBFE-9D18AFCEF374}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{EA2AD408-DAE4-4C92-BBFE-9D18AFCEF374}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{EA2AD408-DAE4-4C92-BBFE-9D18AFCEF374}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{EA2AD408-DAE4-4C92-BBFE-9D18AFCEF374}\HP\MFX,Position,0x10001,1
+;ICEsound
+HKR,SSTPPCfg\{ECCA8785-D74C-42A8-92AF-9A74E8C08B0A}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{ECCA8785-D74C-42A8-92AF-9A74E8C08B0A}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{ECCA8785-D74C-42A8-92AF-9A74E8C08B0A}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{ECCA8785-D74C-42A8-92AF-9A74E8C08B0A}\HP\MFX,Position,0x10001,1
+;Dolby v1.4.1 High Resolution
+HKR,SSTPPCfg\{B5FCC815-1F49-4F4E-B04C-05F3A383EFFF}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{B5FCC815-1F49-4F4E-B04C-05F3A383EFFF}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{B5FCC815-1F49-4F4E-B04C-05F3A383EFFF}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{B5FCC815-1F49-4F4E-B04C-05F3A383EFFF}\HP\MFX,Position,0x10001,1
+;Dolby v1.4.1 lite 
+HKR,SSTPPCfg\{34A7CA4C-B652-4585-9A05-33C8FF01FB81}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{34A7CA4C-B652-4585-9A05-33C8FF01FB81}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{34A7CA4C-B652-4585-9A05-33C8FF01FB81}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{34A7CA4C-B652-4585-9A05-33C8FF01FB81}\HP\MFX,Position,0x10001,1
+;SOUNDRESEARCH 1.1.22.1
+HKR,SSTPPCfg\ {DEA0F608-545D-48C1-91F6-130009FA1357}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\ {DEA0F608-545D-48C1-91F6-130009FA1357}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\ {DEA0F608-545D-48C1-91F6-130009FA1357}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\ {DEA0F608-545D-48C1-91F6-130009FA1357}\HP\MFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{F1B91EB3-7B04-4F86-BBCC-A20C5F57BB5F}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{F1B91EB3-7B04-4F86-BBCC-A20C5F57BB5F}\SPK\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{F1B91EB3-7B04-4F86-BBCC-A20C5F57BB5F}\HP\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{F1B91EB3-7B04-4F86-BBCC-A20C5F57BB5F}\HP\EFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{F5151CC1-D8AA-4F79-8A05-7AB55D8B7A39}\HP\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{F5151CC1-D8AA-4F79-8A05-7AB55D8B7A39}\HP\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{F5151CC1-D8AA-4F79-8A05-7AB55D8B7A39}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{F5151CC1-D8AA-4F79-8A05-7AB55D8B7A39}\SPK\EFX,Position,0x10001,1
+
+HKR,SSTPPCfg\{CBDD3DB0-85AE-4466-B18D-504FD8E7082B}\HP\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{CBDD3DB0-85AE-4466-B18D-504FD8E7082B}\HP\EFX,Position,0x10001,1
+HKR,SSTPPCfg\{CBDD3DB0-85AE-4466-B18D-504FD8E7082B}\SPK\EFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{CBDD3DB0-85AE-4466-B18D-504FD8E7082B}\SPK\EFX,Position,0x10001,1
+
+;THX
+HKR,SSTPPCfg\{E82A5EE8-44D2-44C1-897E-AA5AFBF146BA}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{E82A5EE8-44D2-44C1-897E-AA5AFBF146BA}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{E82A5EE8-44D2-44C1-897E-AA5AFBF146BA}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{E82A5EE8-44D2-44C1-897E-AA5AFBF146BA}\HP\MFX,Position,0x10001,1
+;Dolby 142 Full
+HKR,SSTPPCfg\{DF0CC948-64D1-45C7-BD36-4CDB1E6712F8}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{DF0CC948-64D1-45C7-BD36-4CDB1E6712F8}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{DF0CC948-64D1-45C7-BD36-4CDB1E6712F8}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{DF0CC948-64D1-45C7-BD36-4CDB1E6712F8}\HP\MFX,Position,0x10001,1
+;Dolby 142 Lite
+HKR,SSTPPCfg\{4F9B9C5A-6027-4DF6-9F88-06C2A429ADEA}\SPK\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{4F9B9C5A-6027-4DF6-9F88-06C2A429ADEA}\SPK\MFX,Position,0x10001,1
+HKR,SSTPPCfg\{4F9B9C5A-6027-4DF6-9F88-06C2A429ADEA}\HP\MFX,Enabled,0x10001,1
+HKR,SSTPPCfg\{4F9B9C5A-6027-4DF6-9F88-06C2A429ADEA}\HP\MFX,Position,0x10001,1
+
+;; Name
+
+HKLM,%MediaCategories%\%IntAzAudGuidRearLineOutDac%,Name,,%RearLineOutDacName%
+HKLM,%MediaCategories%\%IntAzAudGuidRearLineOutDac%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%IntAzAudGuidFrontHPOutDac%,Name,,%FrontHPOutDacName%
+HKLM,%MediaCategories%\%IntAzAudGuidFrontHPOutDac%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontMicVolume%,Name,,%Node.FrontMicVolume%
+HKLM,%MediaCategories%\%GUID.FrontMicVolume%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontMicMute%,Name,,%Node.FrontMicMute%
+HKLM,%MediaCategories%\%GUID.FrontMicMute%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.UAJ1%,Name,,%Node.UAJ1%
+HKLM,%MediaCategories%\%GUID.UAJ1%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.UAJ2%,Name,,%Node.UAJ2%
+HKLM,%MediaCategories%\%GUID.UAJ2%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.SPDIF%,Name,,%Node.SPDIF%
+HKLM,%MediaCategories%\%GUID.SPDIF%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontLin%,Name,,%Node.FrontLin%
+HKLM,%MediaCategories%\%GUID.FrontLin%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.Front%,Name,,%Node.Front%
+HKLM,%MediaCategories%\%GUID.Front%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.Surround%,Name,,%Node.Surround%
+HKLM,%MediaCategories%\%GUID.Surround%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.BackSurround%,Name,,%Node.BackSurround%
+HKLM,%MediaCategories%\%GUID.BackSurround%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.Center%,Name,,%Node.Center%
+HKLM,%MediaCategories%\%GUID.Center%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.LFE%,Name,,%Node.LFE%
+HKLM,%MediaCategories%\%GUID.LFE%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.Side%,Name,,%Node.Side%
+HKLM,%MediaCategories%\%GUID.Side%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.SideSurround%,Name,,%Node.SideSurround%
+HKLM,%MediaCategories%\%GUID.SideSurround%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.DigitalOut%,Name,,%Node.DigitalOut%
+HKLM,%MediaCategories%\%GUID.DigitalOut%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.DigitalIn%,Name,,%Node.DigitalIn%
+HKLM,%MediaCategories%\%GUID.DigitalIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.LineInHP%,Name,,%Node.LineInHP%
+HKLM,%MediaCategories%\%GUID.LineInHP%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.Mic2%,Name,,%Node.Mic2%
+HKLM,%MediaCategories%\%GUID.Mic2%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontPinkInOld%,Name,,%Node.FrontPinkIn%
+HKLM,%MediaCategories%\%GUID.FrontPinkInOld%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontGreenInOld%,Name,,%Node.FrontGreenIn%
+HKLM,%MediaCategories%\%GUID.FrontGreenInOld%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.AudioIn%,Name,,%Node.AudioIn%
+HKLM,%MediaCategories%\%GUID.AudioIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontBlackIn%,Name,,%Node.FrontBlackIn%
+HKLM,%MediaCategories%\%GUID.FrontBlackIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontGreyIn%,Name,,%Node.FrontGreyIn%
+HKLM,%MediaCategories%\%GUID.FrontGreyIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontBlueIn%,Name,,%Node.FrontBlueIn%
+HKLM,%MediaCategories%\%GUID.FrontBlueIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontGreenIn%,Name,,%Node.FrontGreenIn%
+HKLM,%MediaCategories%\%GUID.FrontGreenIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontRedIn%,Name,,%Node.FrontRedIn%
+HKLM,%MediaCategories%\%GUID.FrontRedIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontOrangeIn%,Name,,%Node.FrontOrangeIn%
+HKLM,%MediaCategories%\%GUID.FrontOrangeIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontYellowIn%,Name,,%Node.FrontYellowIn%
+HKLM,%MediaCategories%\%GUID.FrontYellowIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontPurpleIn%,Name,,%Node.FrontPurpleIn%
+HKLM,%MediaCategories%\%GUID.FrontPurpleIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontPinkIn%,Name,,%Node.FrontPinkIn%
+HKLM,%MediaCategories%\%GUID.FrontPinkIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontGoldenIn%,Name,,%Node.FrontGoldenIn%
+HKLM,%MediaCategories%\%GUID.FrontGoldenIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontSilverIn%,Name,,%Node.FrontSilverIn%
+HKLM,%MediaCategories%\%GUID.FrontSilverIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontWhiteIn%,Name,,%Node.FrontWhiteIn%
+HKLM,%MediaCategories%\%GUID.FrontWhiteIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearBlackIn%,Name,,%Node.RearBlackIn%
+HKLM,%MediaCategories%\%GUID.RearBlackIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearGreyIn%,Name,,%Node.RearGreyIn%
+HKLM,%MediaCategories%\%GUID.RearGreyIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearBlueIn%,Name,,%Node.RearBlueIn%
+HKLM,%MediaCategories%\%GUID.RearBlueIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearGreenIn%,Name,,%Node.RearGreenIn%
+HKLM,%MediaCategories%\%GUID.RearGreenIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearRedIn%,Name,,%Node.RearRedIn%
+HKLM,%MediaCategories%\%GUID.RearRedIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearOrangeIn%,Name,,%Node.RearOrangeIn%
+HKLM,%MediaCategories%\%GUID.RearOrangeIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearYellowIn%,Name,,%Node.RearYellowIn%
+HKLM,%MediaCategories%\%GUID.RearYellowIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearPurpleIn%,Name,,%Node.RearPurpleIn%
+HKLM,%MediaCategories%\%GUID.RearPurpleIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearPinkIn%,Name,,%Node.RearPinkIn%
+HKLM,%MediaCategories%\%GUID.RearPinkIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearGoldenIn%,Name,,%Node.RearGoldenIn%
+HKLM,%MediaCategories%\%GUID.RearGoldenIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearSilverIn%,Name,,%Node.RearSilverIn%
+HKLM,%MediaCategories%\%GUID.RearSilverIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearWhiteIn%,Name,,%Node.RearWhiteIn%
+HKLM,%MediaCategories%\%GUID.RearWhiteIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.BlackIn%,Name,,%Node.BlackIn%
+HKLM,%MediaCategories%\%GUID.BlackIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.GreyIn%,Name,,%Node.GreyIn%
+HKLM,%MediaCategories%\%GUID.GreyIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.BlueIn%,Name,,%Node.BlueIn%
+HKLM,%MediaCategories%\%GUID.BlueIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.GreenIn%,Name,,%Node.GreenIn%
+HKLM,%MediaCategories%\%GUID.GreenIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RedIn%,Name,,%Node.RedIn%
+HKLM,%MediaCategories%\%GUID.RedIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.OrangeIn%,Name,,%Node.OrangeIn%
+HKLM,%MediaCategories%\%GUID.OrangeIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.YellowIn%,Name,,%Node.YellowIn%
+HKLM,%MediaCategories%\%GUID.YellowIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.PurpleIn%,Name,,%Node.PurpleIn%
+HKLM,%MediaCategories%\%GUID.PurpleIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.PinkIn%,Name,,%Node.PinkIn%
+HKLM,%MediaCategories%\%GUID.PinkIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.GoldenIn%,Name,,%Node.GoldenIn%
+HKLM,%MediaCategories%\%GUID.GoldenIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.SilverIn%,Name,,%Node.SilverIn%
+HKLM,%MediaCategories%\%GUID.SilverIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.WhiteIn%,Name,,%Node.WhiteIn%
+HKLM,%MediaCategories%\%GUID.WhiteIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.AudioInput%,Name,,%Node.AudioInput%
+HKLM,%MediaCategories%\%GUID.AudioInput%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.LineOutVolume%,Name,,%Node.LineOutVolume%
+HKLM,%MediaCategories%\%GUID.LineOutVolume%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.Surr%,Name,,%Node.Surr%
+HKLM,%MediaCategories%\%GUID.Surr%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.Surrback%,Name,,%Node.Surrback%
+HKLM,%MediaCategories%\%GUID.Surrback%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.MonoMic%,Name,,%Node.MonoMic%
+HKLM,%MediaCategories%\%GUID.MonoMic%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.StereoMic%,Name,,%Node.StereoMic%
+HKLM,%MediaCategories%\%GUID.StereoMic%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.PCBeep%,Name,,%Node.PCBeep%
+HKLM,%MediaCategories%\%GUID.PCBeep%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.PcBeepVolume%,Name,,%Node.PcBeepVolume%
+HKLM,%MediaCategories%\%GUID.PcBeepVolume%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.SideHP%,Name,,%Node.SideHP%
+HKLM,%MediaCategories%\%GUID.SideHP%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.MicLineInVolume%,Name,,%Node.MicLineInVolume%
+HKLM,%MediaCategories%\%GUID.MicLineInVolume%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.LineIn1%,Name,,%Node.LineIn1%
+HKLM,%MediaCategories%\%GUID.LineIn1%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.LineIn2%,Name,,%Node.LineIn2%
+HKLM,%MediaCategories%\%GUID.LineIn2%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.TVIn%,Name,,%Node.TVIn%
+HKLM,%MediaCategories%\%GUID.TVIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontAVIn%,Name,,%Node.FrontAVIn%
+HKLM,%MediaCategories%\%GUID.FrontAVIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.LimitedOutput%,Name,,%Node.LimitedOutput%
+HKLM,%MediaCategories%\%GUID.LimitedOutput%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RTSPDIFOut%,Name,,%Node.RTSPDIFOut%
+HKLM,%MediaCategories%\%GUID.RTSPDIFOut%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RTHDMIOut%,Name,,%Node.RTHDMIOut%
+HKLM,%MediaCategories%\%GUID.RTHDMIOut%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RTSPDIFOutRCA%,Name,,%Node.RTSPDIFOutRCA%
+HKLM,%MediaCategories%\%GUID.RTSPDIFOutRCA%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RTSPDIFOutOpt%,Name,,%Node.RTSPDIFOutOpt%
+HKLM,%MediaCategories%\%GUID.RTSPDIFOutOpt%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RTSPDIFIn%,Name,,%Node.RTSPDIFIn%
+HKLM,%MediaCategories%\%GUID.RTSPDIFIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RTHDMIOutAC3%,Name,,%Node.RTHDMIOutAC3%
+HKLM,%MediaCategories%\%GUID.RTHDMIOutAC3%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearLineOutWave3%,Name,,%SingleLineOutWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearLineOutWave3%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearLineOutWave2%,Name,,%PrimaryLineOutWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearLineOutWave2%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.SecondaryLineOutWave%,Name,,%SecondaryLineOutWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.SecondaryLineOutWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearLineInBlackWave%,Name,,%RearLineInBlackWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearLineInBlackWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearLineInGreyWave%,Name,,%RearLineInGreyWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearLineInGreyWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearLineInBlueWave%,Name,,%RearLineInBlueWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearLineInBlueWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearLineInGreenWave%,Name,,%RearLineInGreenWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearLineInGreenWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearLineInRedWave%,Name,,%RearLineInRedWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearLineInRedWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearLineInOrangeWave%,Name,,%RearLineInOrangeWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearLineInOrangeWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearLineInYellowWave%,Name,,%RearLineInYellowWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearLineInYellowWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearLineInPurpleWave%,Name,,%RearLineInPurpleWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearLineInPurpleWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearLineInPinkWave%,Name,,%RearLineInPinkWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearLineInPinkWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearLineInGoldenWave%,Name,,%RearLineInGoldenWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearLineInGoldenWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearLineInSilverWave%,Name,,%RearLineInSilverWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearLineInSilverWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearLineInWhiteWave%,Name,,%RearLineInWhiteWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearLineInWhiteWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearMicInBlackWave%,Name,,%RearMicInBlackWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearMicInBlackWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearMicInGreyWave%,Name,,%RearMicInGreyWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearMicInGreyWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearMicInBlueWave%,Name,,%RearMicInBlueWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearMicInBlueWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearMicInGreenWave%,Name,,%RearMicInGreenWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearMicInGreenWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearMicInRedWave%,Name,,%RearMicInRedWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearMicInRedWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearMicInOrangeWave%,Name,,%RearMicInOrangeWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearMicInOrangeWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearMicInYellowWave%,Name,,%RearMicInYellowWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearMicInYellowWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearMicInPurpleWave%,Name,,%RearMicInPurpleWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearMicInPurpleWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearMicInPinkWave%,Name,,%RearMicInPinkWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearMicInPinkWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearMicInGoldenWave%,Name,,%RearMicInGoldenWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearMicInGoldenWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearMicInSilverWave%,Name,,%RearMicInSilverWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearMicInSilverWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.RearMicInWhiteWave%,Name,,%RearMicInWhiteWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.RearMicInWhiteWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontLineInBlackWave%,Name,,%FrontLineInBlackWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontLineInBlackWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontLineInGreyWave%,Name,,%FrontLineInGreyWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontLineInGreyWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontLineInBlueWave%,Name,,%FrontLineInBlueWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontLineInBlueWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontLineInGreenWave%,Name,,%FrontLineInGreenWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontLineInGreenWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontLineInRedWave%,Name,,%FrontLineInRedWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontLineInRedWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontLineInOrangeWave%,Name,,%FrontLineInOrangeWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontLineInOrangeWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontLineInYellowWave%,Name,,%FrontLineInYellowWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontLineInYellowWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontLineInPurpleWave%,Name,,%FrontLineInPurpleWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontLineInPurpleWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontLineInPinkWave%,Name,,%FrontLineInPinkWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontLineInPinkWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontLineInGoldenWave%,Name,,%FrontLineInGoldenWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontLineInGoldenWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontLineInSilverWave%,Name,,%FrontLineInSilverWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontLineInSilverWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontLineInWhiteWave%,Name,,%FrontLineInWhiteWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontLineInWhiteWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontMicInBlackWave%,Name,,%FrontMicInBlackWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontMicInBlackWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontMicInGreyWave%,Name,,%FrontMicInGreyWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontMicInGreyWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontMicInBlueWave%,Name,,%FrontMicInBlueWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontMicInBlueWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontMicInGreenWave%,Name,,%FrontMicInGreenWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontMicInGreenWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontMicInRedWave%,Name,,%FrontMicInRedWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontMicInRedWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontMicInOrangeWave%,Name,,%FrontMicInOrangeWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontMicInOrangeWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontMicInYellowWave%,Name,,%FrontMicInYellowWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontMicInYellowWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontMicInPurpleWave%,Name,,%FrontMicInPurpleWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontMicInPurpleWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontMicInPinkWave%,Name,,%FrontMicInPinkWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontMicInPinkWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontMicInGoldenWave%,Name,,%FrontMicInGoldenWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontMicInGoldenWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontMicInSilverWave%,Name,,%FrontMicInSilverWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontMicInSilverWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FrontMicInWhiteWave%,Name,,%FrontMicInWhiteWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FrontMicInWhiteWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FjIntrMICWave%,Name,,%FjIntrMICWaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FjIntrMICWave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FjMic1Wave%,Name,,%FjMic1WaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FjMic1Wave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FjLineIn1Wave%,Name,,%FjLineIn1WaveDeviceName%
+HKLM,%MediaCategories%\%GUID.FjLineIn1Wave%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.IntrSubWoofer%,Name,,%IntrSubWooferDeviceName%
+HKLM,%MediaCategories%\%GUID.IntrSubWoofer%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.DigitalMic%,Name,,%Node.DigitalMic%
+HKLM,%MediaCategories%\%GUID.DigitalMic%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.FMRadio%,Name,,%Node.FMRadio%
+HKLM,%MediaCategories%\%GUID.FMRadio%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.2ndMic%,Name,,%Node.2ndMic%
+HKLM,%MediaCategories%\%GUID.2ndMic%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.BTBPOut%,Name,,%Node.BTBPOut%
+HKLM,%MediaCategories%\%GUID.BTBPOut%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.BTBPIn%,Name,,%Node.BTBPIn%
+HKLM,%MediaCategories%\%GUID.BTBPIn%,Display,1,00,00,00,00
+HKLM,%MediaCategories%\%GUID.IntrSubWoofer%,Name,,%IntrSubWooferDeviceName%
+HKLM,%MediaCategories%\%GUID.IntrSubWoofer%,Display,1,00,00,00,00
+
+[Strings]
+MfgName="Realtek"
+OrganizationName="Realtek Semiconductor Corp."
+PackageDisplayName="HD Audio Driver"
+
+MediaCategories="SYSTEM\CurrentControlSet\Control\MediaCategories"
+
+;;
+;; PropertyKey GUIDS
+;;
+PKEY_AudioEndpoint_Supports_EventDriven_Mode = "{1DA5D803-D492-4EDD-8C23-E0C0FFEE7F0E},7"
+
+;;
+;; PKEY_AudioEngine_OEMFormat:  Specifies the default format that is used for rendering/capturing.
+;; vartype = VT_BLOB
+;;
+PKEY_AudioEngine_OEMFormat   = "{E4870E26-3CC5-4CD2-BA46-CA0A9A70ED04},3"
+PKEY_SupportFormat_OEMFormat = "{B3F8FA53-0004-438E-9003-51A46E139BFC},5"
+
+KSNODETYPE_ANY              = "{00000000-0000-0000-0000-000000000000}"
+KSNODETYPE_HDMI_INTERFACE   = "{D1B9CC2A-F519-417f-91C9-55FA65481001}"
+REG_BINARY                  = 0x00000001
+
+RearLineOutWaveDeviceName="Realtek HD Audio rear output"
+RearLineOutTopoDeviceName="Realtek HD rear output mixer"
+RearLineOutDacName="HD Line Out DAC(s) for rear panel"
+
+SecondaryLineInWaveDeviceName="Realtek HD Audio 2nd input"
+SecondaryLineInTopoDeviceName="Realtek HD rear 2nd mixer"
+
+PrimaryLineInWaveDeviceName="Realtek HDA Primary input"
+PrimaryLineInTopoDeviceName="Realtek HD rear Primary mixer"
+
+PrimaryLineOutWaveDeviceName="Realtek HDA Primary output"
+PrimaryLineOutTopoDeviceName="Realtek HD Primary output mixer"
+
+SingleLineOutWaveDeviceName="Realtek HD Audio output"
+SingleLineOutTopoDeviceName="Realtek HD Audio output mixer"
+
+SingleLineInWaveDeviceName="Realtek HD Audio input"
+SingleLineInTopoDeviceName="Realtek HD input mixer"
+
+SecondaryLineOutWaveDeviceName="Realtek HD Audio 2nd output"
+SecondaryLineOutTopoDeviceName="Realtek HD Secondary output mixer"
+
+HPRearCaptureWaveDeviceName="Back Line in/Mic, Front Line in"
+HPRearCaptureTopoDeviceName="Rear input, Front Line in mixer"
+
+HPCPCCaptureWaveDeviceName="Line in/Mic in"
+HPCPCCaptureTopoDeviceName="Line in/Mic in Mixer"
+
+RearMicInWaveDeviceName="Realtek HD rear Mic in"
+RearMicInTopoDeviceName="Realtek HD rear Mic in Mixer"
+
+FrontPanelHeadphoneWaveDeviceName="Realtek HD Audio front output"
+FrontPanelHeadphoneTopoDeviceName="Realtek HD front output mixer"
+FrontHPOutDacName="HD Headphone DAC for front panel" 
+
+DigitalInputWaveDeviceName="Realtek HD Digital input"
+DigitalInputTopoDeviceName="Realtek HD Digital input mixer"
+
+IntcAzAudioDeviceDescription = "Realtek High Definition Audio(SST)"
+
+DigitalMICWaveDeviceName="Realtek Digital Microphone"
+DigitalMICTopoDeviceName="Realtek Digital Microphone mixer"
+
+RearLineInBlackWaveDeviceName="Line in at rear panel (black)"
+RearLineInBlackTopoDeviceName="Line in at rear mixer (black)"
+RearLineInGreyWaveDeviceName="Line in at rear panel (Grey)"
+RearLineInGreyTopoDeviceName="Line in at rear mixer (Grey)"
+RearLineInBlueWaveDeviceName="Line in at rear panel (Blue)"
+RearLineInBlueTopoDeviceName="Line in at rear mixer (Blue)"
+RearLineInGreenWaveDeviceName="Line in at rear panel (Green)"
+RearLineInGreenTopoDeviceName="Line in at rear mixer (Green)"
+RearLineInRedWaveDeviceName="Line in at rear panel (Red)"
+RearLineInRedTopoDeviceName="Line in at rear mixer (Red)"
+RearLineInOrangeWaveDeviceName="Line in at rear panel (Orange)"
+RearLineInOrangeTopoDeviceName="Line in at rear mixer (Orange)"
+RearLineInYellowWaveDeviceName="Line in at rear panel (Yellow)"
+RearLineInYellowTopoDeviceName="Line in at rear mixer (Yellow)"
+RearLineInPurpleWaveDeviceName="Line in at rear panel (Purple)"
+RearLineInPurpleTopoDeviceName="Line in at rear mixer (Purple)"
+RearLineInPinkWaveDeviceName="Line in at rear panel (Pink)"
+RearLineInPinkTopoDeviceName="Line in at rear mixer (Pink)"
+RearLineInGoldenWaveDeviceName="Line in at rear panel (Golden)"
+RearLineInGoldenTopoDeviceName="Line in at rear mixer (Golden)"
+RearLineInSilverWaveDeviceName="Line in at rear panel (Silver)"
+RearLineInSilverTopoDeviceName="Line in at rear mixer (Silver)"
+RearLineInWhiteWaveDeviceName="Line in at rear panel (White)"
+RearLineInWhiteTopoDeviceName="Line in at rear mixer (White)"
+RearMicInBlackWaveDeviceName="Mic in at rear panel (black)"
+RearMicInBlackTopoDeviceName="Mic in at rear mixer (black)"
+RearMicInGreyWaveDeviceName="Mic in at rear panel (Grey)"
+RearMicInGreyTopoDeviceName="Mic in at rear mixer (Grey)"
+RearMicInBlueWaveDeviceName="Mic in at rear panel (Blue)"
+RearMicInBlueTopoDeviceName="Mic in at rear mixer (Blue)"
+RearMicInGreenWaveDeviceName="Mic in at rear panel (Green)"
+RearMicInGreenTopoDeviceName="Mic in at rear mixer (Green)"
+RearMicInRedWaveDeviceName="Mic in at rear panel (Red)"
+RearMicInRedTopoDeviceName="Mic in at rear mixer (Red)"
+RearMicInOrangeWaveDeviceName="Mic in at rear panel (Orange)"
+RearMicInOrangeTopoDeviceName="Mic in at rear mixer (Orange)"
+RearMicInYellowWaveDeviceName="Mic in at rear panel (Yellow)"
+RearMicInYellowTopoDeviceName="Mic in at rear mixer (Yellow)"
+RearMicInPurpleWaveDeviceName="Mic in at rear panel (Purple)"
+RearMicInPurpleTopoDeviceName="Mic in at rear mixer (Purple)"
+RearMicInPinkWaveDeviceName="Mic in at rear panel (Pink)"
+RearMicInPinkTopoDeviceName="Mic in at rear mixer (Pink)"
+RearMicInGoldenWaveDeviceName="Mic in at rear panel (Golden)"
+RearMicInGoldenTopoDeviceName="Mic in at rear mixer (Golden)"
+RearMicInSilverWaveDeviceName="Mic in at rear panel (Silver)"
+RearMicInSilverTopoDeviceName="Mic in at rear mixer (Silver)"
+RearMicInWhiteWaveDeviceName="Mic in at rear panel (White)"
+RearMicInWhiteTopoDeviceName="Mic in at rear mixer (White)"
+FrontLineInBlackWaveDeviceName="Line in at front panel (black)"
+FrontLineInBlackTopoDeviceName="Line in at front mixer (black)"
+FrontLineInGreyWaveDeviceName="Line in at front panel (Grey)"
+FrontLineInGreyTopoDeviceName="Line in at front mixer (Grey)"
+FrontLineInBlueWaveDeviceName="Line in at front panel (Blue)"
+FrontLineInBlueTopoDeviceName="Line in at front mixer (Blue)"
+FrontLineInGreenWaveDeviceName="Line in at front panel (Green)"
+FrontLineInGreenTopoDeviceName="Line in at front mixer (Green)"
+FrontLineInRedWaveDeviceName="Line in at front panel (Red)"
+FrontLineInRedTopoDeviceName="Line in at front mixer (Red)"
+FrontLineInOrangeWaveDeviceName="Line in at front panel (Orange)"
+FrontLineInOrangeTopoDeviceName="Line in at front mixer (Orange)"
+FrontLineInYellowWaveDeviceName="Line in at front panel (Yellow)"
+FrontLineInYellowTopoDeviceName="Line in at front mixer (Yellow)"
+FrontLineInPurpleWaveDeviceName="Line in at front panel (Purple)"
+FrontLineInPurpleTopoDeviceName="Line in at front mixer (Purple)"
+FrontLineInPinkWaveDeviceName="Line in at front panel (Pink)"
+FrontLineInPinkTopoDeviceName="Line in at front mixer (Pink)"
+FrontLineInGoldenWaveDeviceName="Line in at front panel (Golden)"
+FrontLineInGoldenTopoDeviceName="Line in at front mixer (Golden)"
+FrontLineInSilverWaveDeviceName="Line in at front panel (Silver)"
+FrontLineInSilverTopoDeviceName="Line in at front mixer (Silver)"
+FrontLineInWhiteWaveDeviceName="Line in at front panel (White)"
+FrontLineInWhiteTopoDeviceName="Line in at front mixer (White)"
+FrontMicInBlackWaveDeviceName="Mic in at front panel (black)"
+FrontMicInBlackTopoDeviceName="Mic in at front mixer (black)"
+FrontMicInGreyWaveDeviceName="Mic in at front panel (Grey)"
+FrontMicInGreyTopoDeviceName="Mic in at front mixer (Grey)"
+FrontMicInBlueWaveDeviceName="Mic in at front panel (Blue)"
+FrontMicInBlueTopoDeviceName="Mic in at front mixer (Blue)"
+FrontMicInGreenWaveDeviceName="Mic in at front panel (Green)"
+FrontMicInGreenTopoDeviceName="Mic in at front mixer (Green)"
+FrontMicInRedWaveDeviceName="Mic in at front panel (Red)"
+FrontMicInRedTopoDeviceName="Mic in at front mixer (Red)"
+FrontMicInOrangeWaveDeviceName="Mic in at front panel (Orange)"
+FrontMicInOrangeTopoDeviceName="Mic in at front mixer (Orange)"
+FrontMicInYellowWaveDeviceName="Mic in at front panel (Yellow)"
+FrontMicInYellowTopoDeviceName="Mic in at front mixer (Yellow)"
+FrontMicInPurpleWaveDeviceName="Mic in at front panel (Purple)"
+FrontMicInPurpleTopoDeviceName="Mic in at front mixer (Purple)"
+FrontMicInPinkWaveDeviceName="Mic in at front panel (Pink)"
+FrontMicInPinkTopoDeviceName="Mic in at front mixer (Pink)"
+FrontMicInGoldenWaveDeviceName="Mic in at front panel (Golden)"
+FrontMicInGoldenTopoDeviceName="Mic in at front mixer (Golden)"
+FrontMicInSilverWaveDeviceName="Mic in at front panel (Silver)"
+FrontMicInSilverTopoDeviceName="Mic in at front mixer (Silver)"
+FrontMicInWhiteWaveDeviceName="Mic in at front panel (White)"
+FrontMicInWhiteTopoDeviceName="Mic in at front mixer (White)"
+FjIntrMICWaveDeviceName="Internal MIC"
+FjMic1WaveDeviceName="MIC In"
+FjLineIn1WaveDeviceName="Line In"
+RtSpdifWaveDeviceName="Realtek HDA SPDIF Out"
+RtSpdifTopoDeviceName="Realtek HDA SPDIF Out Mixer"
+RtSpdifHDMIWaveDeviceName="Realtek HDA HDMI Out"
+RtSpdifHDMITopoDeviceName="Realtek HDA HDMI Out Mixer"
+RtSpdifRCAWaveDeviceName="Realtek HDA SPDIF RCA Out"
+RtSpdifRCATopoDeviceName="Realtek HDA SPDIF RCA Out Mixer"
+RtSpdifOptWaveDeviceName="Realtek HDA SPDIF Optical Out"
+RtSpdifOptTopoDeviceName="Realtek HDA SPDIF Optical Out Mixer"
+IntrSubWooferDeviceName="Internal Subwoofer"
+
+RtStereoMixWaveDeviceName="Realtek HD Audio Stereo input"
+RtLineInWaveDeviceName="Realtek HD Audio Line input"
+RtCDInWaveDeviceName="Realtek HD Audio CD input"
+RtAuxInWaveDeviceName="Realtek HD Audio AUX input"
+RtFrontMicInWaveDeviceName="Realtek HD Audio Front Mic input"
+RtFrontLineInWaveDeviceName="Realtek HD Audio Front Line input"
+RtMicArWaveDeviceName="Realtek HD Audio Mic Array input"
+
+RtStereoMixTopoDeviceName="Realtek HD Audio Stereo input mixer"
+RtLineInTopoDeviceName="Realtek HD Audio Line input mixer"
+RtCDInTopoDeviceName="Realtek HD Audio CD input mixer"
+RtAuxInTopoDeviceName="Realtek HD Audio AUX input mixer"
+RtFrontMicInTopoDeviceName="Realtek HD Audio Front Mic input mixer"
+RtFrontLineInTopoDeviceName="Realtek HD Audio Front Line input mixer"
+RtMicArTopoDeviceName="Realtek HD Audio Mic Array mixer"
+
+KSCATEGORY_AUDIO    = "{6994AD04-93EF-11D0-A3CC-00A0C9223196}"
+KSCATEGORY_RENDER   = "{65E8773E-8F56-11D0-A3B9-00A0C9223196}"
+KSCATEGORY_REALTIME = "{EB115FFC-10C8-4964-831D-6DCB02E6F23F}"
+KSCATEGORY_CAPTURE  = "{65E8773D-8F56-11D0-A3B9-00A0C9223196}"
+KSCATEGORY_TOPOLOGY = "{DDA54A40-1E4C-11D1-A050-405705C10000}"
+Proxy.CLSID         = "{17CCA71B-ECD7-11D0-B908-00A0C9223196}"
+
+; guids for rear line out
+IntAzAudGuidRearLineOutDac= "{EEF86A90-3742-4974-B8D2-5370E1C540F6}"
+IntAzAudGuidFrontHPOutDac = "{497B34AD-D67F-411c-8076-80D5B4250D67}"
+
+;; Node
+GUID.FrontMicVolume     ="{8E1FC059-D41D-417f-8103-FC592A4B32C8}"
+GUID.FrontMicMute       ="{65D86BEA-A16C-4e40-9F01-50C559D721B9}"
+GUID.UAJ1               ="{E7CD3EA7-072F-4d9f-B94A-744108964E0E}"
+GUID.UAJ2               ="{93FCBD9E-08CD-4cbd-B018-5EE0B83E7AF0}"
+GUID.SPDIF              ="{7B1A60BA-4F2D-41f6-95B1-5589F90D1ECE}"
+GUID.FrontLin           ="{757AB5CF-F4D5-42e4-9609-BF78FC6C712B}"
+GUID.Front              ="{8A74FFAE-8766-480f-AF6D-325FCF9AB324}"
+GUID.Surround           ="{B25A6526-9703-4117-9D7F-260A5DF5CC34}"
+GUID.BackSurround       ="{366E009F-CC06-495c-9959-13E7986FA760}"
+GUID.Center             ="{594AC582-B82A-4024-99E7-DC5B358E0F30}"
+GUID.LFE                ="{19532773-C332-4de7-BEDD-F888163C3094}"
+GUID.Side               ="{A5B27DE2-40F3-469e-9A4D-2CD8D5D9284D}"
+GUID.SideSurround       ="{32DD8857-C301-45b4-AB78-4D35E58402DC}"
+GUID.DigitalOut         ="{7CB80EC0-9C2D-4924-AA30-3DB3864F8CD6}"
+GUID.DigitalIn          ="{4F30E318-2B36-4b46-AF17-36A336363A12}"
+GUID.LineInHP           ="{B001EDFD-CF09-402f-8652-2E32AE568508}"
+GUID.Mic2               ="{2216D589-3C9F-4843-B4E9-933F2ABCA6D2}"
+GUID.FrontPinkInOld     ="{39E595A1-9F2B-4276-A416-8D7A1534F01C}"
+GUID.FrontGreenInOld    ="{38CB5F75-F95A-425c-8444-F1C18942DB14}"
+GUID.AudioIn            ="{D4649B85-6687-4ec4-8C65-5B7B6248C470}"
+GUID.LineOutVolume      ="{9ACC8A34-DBF9-416d-97E7-3B90FE28FBD1}"
+GUID.PcBeepVolume       ="{093C0065-6B45-4582-87D7-5A6742F6E859}"
+GUID.Surr               ="{38D6C869-D317-4dd2-B1B0-A9CAD8DD9639}"
+GUID.Surrback           ="{C6E24B42-19BF-4211-9021-C696E3284C4F}"
+GUID.MonoMic            ="{3BEFF10F-1EC8-448f-9654-73067CCE3C6A}"
+GUID.StereoMic          ="{AA23B58F-B6D2-4952-B318-A0304B7EDEB3}"
+GUID.PCBeep             ="{C57704A3-108F-4760-99BA-6369AD13345D}"
+GUID.SideHP             ="{C61C32C2-2BE7-467e-A278-B49E6746921E}"
+GUID.MicLineInVolume    ="{5B08FA7D-A8BC-42a6-A1A9-C52AB5FC47A7}"
+
+;; Nodes (localizeable)
+Node.FrontMicVolume     ="FrontMic"
+Node.FrontMicMute       ="FrontMic Mute"
+Node.UAJ1               ="FPink"
+Node.UAJ2               ="FGreen"
+Node.SPDIF              ="SPDIF"
+Node.FrontLin           ="FrontLineIn"
+Node.Front              ="Front"
+Node.Surround           ="Rear"
+Node.BackSurround       ="Back Surround"
+Node.Center             ="Center"
+Node.LFE                ="Subwoofer"
+Node.Side               ="Side"
+Node.SideSurround       ="Side Surround"
+Node.DigitalOut         ="DigitalOut"
+Node.DigitalIn          ="DigitalIn"
+Node.LineInHP           ="Line In 1 or 2"
+Node.Mic2               ="Microphone2"
+Node.FrontPinkInOld     ="FrontPink In"
+Node.FrontGreenInOld    ="FrontGreen In"
+Node.AudioIn            ="Audio In"
+Node.LineOutVolume      ="Line Out"
+Node.Surr               ="Surround"
+Node.Surrback           ="Surr-Back"
+Node.MonoMic            ="Mono Mic"
+Node.StereoMic          ="Stereo Mic"
+Node.PCBeep             ="PC Beep"
+Node.PcBeepVolume       ="PC Beep"
+Node.SideHP             ="Side/HP"
+Node.MicLineInVolume    ="Mic/Line In"
+
+GUID.FrontBlackIn            ="{C1857CBB-5FEA-420c-89FD-0479D7D366FB}"
+Node.FrontBlackIn            ="Front Black In"
+GUID.FrontGreyIn             ="{74B67688-4723-4ec7-A1A6-09F33FF91FDB}"
+Node.FrontGreyIn             ="Front Grey In"
+GUID.FrontBlueIn             ="{9B0DC1D3-EFC8-4364-8ACD-9172D388F487}"
+Node.FrontBlueIn             ="Front Blue In"
+GUID.FrontGreenIn            ="{BA697E2A-BC14-4c0d-9E16-3935F2F15E08}"
+Node.FrontGreenIn            ="Front Green In"
+GUID.FrontRedIn              ="{AC846E6F-5695-4cec-B694-956A2E689AF4}"
+Node.FrontRedIn              ="Front Red In"
+GUID.FrontOrangeIn           ="{C2BEEC11-5DF2-4fd9-B2D1-B5E2A1E46CB7}"
+Node.FrontOrangeIn           ="Front Orange In"
+GUID.FrontYellowIn           ="{783FFBEB-79D4-40b8-BBB4-B90479D17F1F}"
+Node.FrontYellowIn           ="Front Yellow In"
+GUID.FrontPurpleIn           ="{0D95D21C-2FF7-4a66-9526-CC39DA3E749E}"
+Node.FrontPurpleIn           ="Front Purple In"
+GUID.FrontPinkIn             ="{930A479F-0487-4baa-9672-4C7C36C0EFB2}"
+Node.FrontPinkIn             ="Front Pink In"
+GUID.FrontGoldenIn           ="{8FED8EA0-0485-408c-9963-D3AC59D34A1F}"
+Node.FrontGoldenIn           ="Front Golden In"
+GUID.FrontSilverIn           ="{FB0CBA7B-73ED-4880-9A7F-338D67AB1E71}"
+Node.FrontSilverIn           ="Front Silver In"
+GUID.FrontWhiteIn            ="{788F5056-8394-4bf5-8608-B8BC009F9B0D}"
+Node.FrontWhiteIn            ="Front White In"
+GUID.RearBlackIn             ="{16238C4C-5B07-4acf-9B1D-72056187853C}"
+Node.RearBlackIn             ="Rear Black In"
+GUID.RearGreyIn              ="{066ED7CF-26FC-4cd6-8DB0-BDA088FFC7B6}"
+Node.RearGreyIn              ="Rear Grey In"
+GUID.RearBlueIn              ="{25C9B7B5-B490-4418-B8C9-AE6A9E597D10}"
+Node.RearBlueIn              ="Rear Blue In"
+GUID.RearGreenIn             ="{D5841A06-2012-49bb-848A-4E3C9D8E83EC}"
+Node.RearGreenIn             ="Rear Green In"
+GUID.RearRedIn               ="{EEB9FF66-875E-44d0-A7BC-94F8FF8A6B2E}"
+Node.RearRedIn               ="Rear Red In"
+GUID.RearOrangeIn            ="{656A2737-0A8D-4c24-B11B-2CF3568DF248}"
+Node.RearOrangeIn            ="Rear Orange In"
+GUID.RearYellowIn            ="{EA1B271B-D19A-41ea-9141-E0FE75259300}"
+Node.RearYellowIn            ="Rear Yellow In"
+GUID.RearPurpleIn            ="{D907F836-CE83-4354-B62C-B9700CCC0366}"
+Node.RearPurpleIn            ="Rear Purple In"
+GUID.RearPinkIn              ="{CECB705D-C0D9-4c47-84F6-0A210E9DFD0B}"
+Node.RearPinkIn              ="Rear Pink In"
+GUID.RearGoldenIn            ="{98B9900B-618A-4bd3-9B62-B206E9AA5F6F}"
+Node.RearGoldenIn            ="Rear Golden In"
+GUID.RearSilverIn            ="{B8CE8B6A-A73E-494d-8218-F308670F6149}"
+Node.RearSilverIn            ="Rear Silver In"
+GUID.RearWhiteIn             ="{6D33D369-990F-444b-A4E6-57A29B8F0993}"
+Node.RearWhiteIn             ="Rear White In"
+
+GUID.BlackIn            ="{2AFE8623-D5B6-49d6-898D-A16A616E571B}"
+Node.BlackIn            ="Black In"
+GUID.GreyIn             ="{8A965A50-6F78-424c-8EDD-DD904C4C7AAC}"
+Node.GreyIn             ="Grey In"
+GUID.BlueIn             ="{CD2AAD6D-761E-4b6d-A4C6-8F543A38C099}"
+Node.BlueIn             ="Blue In"
+GUID.GreenIn            ="{5153DE62-8983-4a02-8F87-2969BC2A279A}"
+Node.GreenIn            ="Green In"
+GUID.RedIn              ="{6735C4E4-C0DA-473f-8D1F-2FD185C83071}"
+Node.RedIn              ="Red In"
+GUID.OrangeIn           ="{B89B4F6B-5820-46a0-999C-A9765221DA30}"
+Node.OrangeIn           ="Orange In"
+GUID.YellowIn           ="{D7F95568-524C-4ef1-A58E-1E8BF3E4443E}"
+Node.YellowIn           ="Yellow In"
+GUID.PurpleIn           ="{A57DE92C-E432-4432-8166-E02D8C4ACDDC}"
+Node.PurpleIn           ="Purple In"
+GUID.PinkIn             ="{C0F074E4-0F6A-4b6f-BC09-5DF75D24757F}"
+Node.PinkIn             ="Pink In"
+GUID.GoldenIn           ="{72DA7D85-CCB7-4bce-BDD7-A8F0E56958B8}"
+Node.GoldenIn           ="Golden In"
+GUID.SilverIn           ="{892B95E3-FEA5-48b2-93B8-49373E588E38}"
+Node.SilverIn           ="Silver In"
+GUID.WhiteIn            ="{710CE1E3-334A-4771-A4B2-CFFF54B70DBF}"
+Node.WhiteIn            ="White In"
+GUID.AudioInput         ="{B8B35FC5-6051-44e0-A3CE-B6E000564C64}"
+Node.AudioInput         ="Audio Input"
+GUID.LineIn1            ="{1B5D1795-4D18-4057-81DA-06A5FC19F3AC}"
+GUID.LineIn2            ="{AD8341CB-C580-46e7-B593-44440EFB4DE8}"
+Node.LineIn1            ="Line In 1"
+Node.LineIn2            ="Line In 2"
+GUID.TVIn               ="{38FAF4E0-3EEF-47d7-AD52-F20AB10340C3}"
+Node.TVIn               ="TV In"
+GUID.FrontAVIn          ="{E27EEDDE-A24D-4f87-8EDE-5A58E7FF8D70}"
+Node.FrontAVIn          ="Front AV In"
+GUID.LimitedOutput	    ="{D172D8CE-0235-4b09-92EB-BDE320CFB94C}"
+Node.LimitedOutput	    ="Limited Output"
+
+GUID.RTSPDIFOut			="{8FD300D2-FFE1-44f3-A9EB-6F4395D73C9F}"
+Node.RTSPDIFOut			="Realtek Digital Output"
+GUID.RTHDMIOut			="{9C8E490E-877D-48fe-9EF1-AD83C91CC057}"
+Node.RTHDMIOut			="Realtek HDMI Output"
+GUID.RTSPDIFOutRCA		="{3FF4EDB6-3FF3-4b5a-B164-10FFF0367547}"
+Node.RTSPDIFOutRCA		="Realtek Digital Output(RCA)"
+GUID.RTSPDIFOutOpt		="{94FCA009-B26E-4cdc-AC75-051613EF01BB}"
+Node.RTSPDIFOutOpt		="Realtek Digital Output(Optical)"
+GUID.RTHDMIOutAC3		="{5E66F238-FF5B-49b9-B3BA-4E8F65399FCD}"
+Node.RTHDMIOutAC3		="Allow AC3/DTS/WMA output.(Reboot required)"
+
+GUID.RTSPDIFIn			="{8FD300D3-FFE1-44f3-A9EB-6F4395D73C9F}"
+Node.RTSPDIFIn			="Realtek Digital Input"
+
+GUID.RearLineOutWave3   ="{FDCD16F9-7895-4f2c-9E95-2C4F62DE500D}"
+GUID.RearLineOutWave2   ="{73EC718D-EEBD-4305-BD56-E50807C4B3E2}"
+GUID.SecondaryLineOutWave ="{D0D252D2-0D9A-47f7-B44B-3FB73C31F6FA}"
+
+GUID.RearLineInBlackWave  ="{29FAD4B6-42C6-46fe-85D2-772B3F38E42B}"
+GUID.RearLineInGreyWave   ="{5D3113BA-46E3-4e48-BF97-5E1486E5C845}"
+GUID.RearLineInBlueWave   ="{6EDFC84F-270B-43f4-A4DA-F4FA32BE0023}"
+GUID.RearLineInGreenWave  ="{4C28B434-D501-4131-A626-D667F954A279}"
+GUID.RearLineInRedWave    ="{F9C764D1-0A97-4216-BD80-57D11C86BF21}"
+GUID.RearLineInOrangeWave ="{FA3C462A-11E7-4cfe-9C20-4208E87EE2F1}"
+GUID.RearLineInYellowWave ="{242792D9-E16F-4e09-9F4A-FD5C910230F2}"
+GUID.RearLineInPurpleWave ="{64593A8D-8942-415f-83F7-495232599984}"
+GUID.RearLineInPinkWave   ="{3FAF44E8-FC47-4921-AA2A-CB511CD5A340}"
+GUID.RearLineInGoldenWave ="{A18CE952-B042-42d4-AE98-6AD616604407}"
+GUID.RearLineInSilverWave ="{9ABF55D5-4319-4e1e-A1E6-D720FB153A73}"
+GUID.RearLineInWhiteWave  ="{39514CCF-B424-454d-A2DD-7CCCC41902CC}"
+
+GUID.RearMicInBlackWave   ="{963BB9C2-C99A-4278-8C85-0A53FAD66593}"
+GUID.RearMicInGreyWave    ="{750D77D8-DD18-45fa-813B-31AAF37D8816}"
+GUID.RearMicInBlueWave    ="{D09B4160-D155-4409-814C-7BDFD3DCC115}"
+GUID.RearMicInGreenWave   ="{E63A12AB-7A2A-40bf-B5F5-176F3E17A75B}"
+GUID.RearMicInRedWave     ="{397BCD99-443F-4f0a-91F7-8CF33B73E7B5}"
+GUID.RearMicInOrangeWave  ="{DF15C716-2E97-498c-953B-71B1A6E4BD03}"
+GUID.RearMicInYellowWave  ="{A80B8021-3A94-4cba-A31F-A30285215AEB}"
+GUID.RearMicInPurpleWave  ="{ADA7C584-EC2C-4bad-9491-38EA3EDC364E}"
+GUID.RearMicInPinkWave    ="{9767F352-1066-4606-B843-EB3DFF14AE48}"
+GUID.RearMicInGoldenWave  ="{0BF09DFA-1DC9-45d6-9E68-B62FCE22F574}"
+GUID.RearMicInSilverWave  ="{D88BF175-E66E-41f6-91A0-1AE5BD7FB550}"
+GUID.RearMicInWhiteWave   ="{C949BDB2-0F63-411d-9A1C-FF2C68137986}"
+
+GUID.FrontLineInBlackWave ="{E922348B-F538-48f2-8A46-03610CA3C815}"
+GUID.FrontLineInGreyWave  ="{F84AD65F-8888-4076-BA55-15FA42C66D43}"
+GUID.FrontLineInBlueWave  ="{EEA8F0C2-15F2-47ba-9939-8B68B99B5A47}"
+GUID.FrontLineInGreenWave ="{D9CFB32D-C42A-446d-8D3D-BE3ACF1FE392}"
+GUID.FrontLineInRedWave   ="{37E6001D-7297-439e-BB83-EAAA48F54DE1}"
+GUID.FrontLineInOrangeWave="{0FBC7B0C-368C-468a-ADCA-A9C1DFD67B01}"
+GUID.FrontLineInYellowWave="{C1601920-82B6-411d-B1EB-F1B8A9DD2DCD}"
+GUID.FrontLineInPurpleWave="{F32BA73A-930B-4596-A47F-A9339FB7E24C}"
+GUID.FrontLineInPinkWave  ="{9EC96236-A9B3-45b3-8E19-C4F424399457}"
+GUID.FrontLineInGoldenWave="{9F31B40E-E3D2-4683-8CD8-DD29972CBD6A}"
+GUID.FrontLineInSilverWave="{9B706B3E-F3FE-4d4b-B410-468D3E083D98}"
+GUID.FrontLineInWhiteWave ="{6E56DB59-D4D1-4fa8-9575-AE39763E14C7}"
+
+GUID.FrontMicInBlackWave  ="{063C7B0E-7D63-45ea-BD17-BD2383C9DA48}"
+GUID.FrontMicInGreyWave   ="{F6810363-D355-4c27-B60C-DB10B4A6DB1F}"
+GUID.FrontMicInBlueWave   ="{4872BA3F-61F9-495f-97C1-0FC6D149B0D8}"
+GUID.FrontMicInGreenWave  ="{564C8501-3C26-4051-B3DF-80157C565158}"
+GUID.FrontMicInRedWave    ="{FA5703D8-BC38-4759-BDDB-53A0A9977D86}"
+GUID.FrontMicInOrangeWave ="{2F055121-7B49-4389-AE10-6D8FDB6F9E15}"
+GUID.FrontMicInYellowWave ="{67DC169B-1C82-4fb7-B566-CC917F303CD7}"
+GUID.FrontMicInPurpleWave ="{8DE7D024-880C-4a50-BFBA-6118FA703728}"
+GUID.FrontMicInPinkWave   ="{D3D9A153-5556-40a7-8C1B-E476344A524A}"
+GUID.FrontMicInGoldenWave ="{4F8E73AF-13D0-4ab4-BD05-DA13475B6D99}"
+GUID.FrontMicInSilverWave ="{9B72B3D3-32F5-4d3b-868E-C506824ED45A}"
+GUID.FrontMicInWhiteWave  ="{53824709-A7CA-4432-9423-D47A01938B83}"
+
+GUID.FjIntrMICWave        ="{703EFE0E-C7D3-4506-96BF-E2D28E2ECEEE}"
+GUID.FjMic1Wave           ="{703EFE0D-C7D3-4506-96BF-E2D28E2ECEEE}"
+GUID.FjLineIn1Wave        ="{703EFE0C-C7D3-4506-96BF-E2D28E2ECEEE}"
+
+GUID.DigitalMic           ="{7DF69A32-C356-4f5a-A3BB-757B8B5177D4}"
+Node.DigitalMic           ="Digital Mic"
+
+GUID.FMRadio              ="{93ED2CB4-7D0D-4c1c-8A91-5AE457E066AD}"
+Node.FMRadio              ="FM radio"
+GUID.2ndMic               ="{8D6EF1FE-9E90-43eb-8E0D-7411B70AB6AC}"
+Node.2ndMic               ="2nd Mic"
+GUID.BTBPOut              ="{8D6EF1FE-9E91-43eb-8E0D-7411B70AB6AC}"
+Node.BTBPOut              ="Bluetooth bypass output"
+GUID.BTBPIn               ="{8D6EF1FE-9E92-43eb-8E0D-7411B70AB6AC}"
+Node.BTBPIn               ="Bluetooth bypass input"
+
+GUID.IntrSubWoofer        ="{CE407554-302B-44a8-9455-BB933694A1A5}"

--- a/InfHelperTests/src/InfHelperTests.cs
+++ b/InfHelperTests/src/InfHelperTests.cs
@@ -80,7 +80,7 @@ namespace InfHelperTests
         public void SearchMethdTest()
         {
             string formula =
-                "[DestinationDirs]\r\nRazer_CoInstaller_CopyFiles = 11\r\nRazer_Installer_CopyFiles = 16422,\"Razer\\RzWizardPkg\"\r\nRazer_Installer_CopyFilesWOW64 = 16426,\"Razer\\RzWizardPkg\"";
+                "[DestinationDirs]\r\nRazer_CoInstaller_CopyFiles = 11 ; Comment\r\nRazer_Installer_CopyFiles = 16422,\"Razer\\RzWizardPkg\"\r\nRazer_Installer_CopyFilesWOW64 = 16426,\"Razer\\RzWizardPkg\"";
             var helper = new InfUtil();
             var data = helper.Parse(formula);
             Assert.AreEqual("11", data.FindKeyById("Razer_CoInstaller_CopyFiles").First().PrimitiveValue);

--- a/InfHelperTests/src/InfHelperTests.cs
+++ b/InfHelperTests/src/InfHelperTests.cs
@@ -72,13 +72,13 @@ namespace InfHelperTests
                 "Razer_CoInstaller_CopyFiles = 11\r\n" +
                 "Razer_Installer_CopyFiles = 16422,\"Razer\\RzWizardPkg\"\r\n" +
                 "Razer_Installer_CopyFilesWOW64 = 16426,\"Razer\\RzWizardPkg\"\r\n" +
-                "Razer_Installer_CopyFilesWithBrackets = 16428,\"Razer\\RzWizardPkg [Brackets=X]\"";
+                "Razer_Installer_CopyFilesWithBrackets = 16428,\"Razer\\RzWizardPkg ; [Brackets=X]\"";
             var helper = new InfUtil();
             var data = helper.Parse(formula);
             Assert.AreEqual("11", data["DestinationDirs"]["Razer_CoInstaller_CopyFiles"].PrimitiveValue);
             Assert.AreEqual("16422, \"Razer\\RzWizardPkg\"", data["DestinationDirs"]["Razer_Installer_CopyFiles"].PrimitiveValue);
             Assert.AreEqual("16426, \"Razer\\RzWizardPkg\"", data["DestinationDirs"]["Razer_Installer_CopyFilesWOW64"].PrimitiveValue);
-            Assert.AreEqual("16428, \"Razer\\RzWizardPkg [Brackets=X]\"", data["DestinationDirs"]["Razer_Installer_CopyFilesWithBrackets"].PrimitiveValue);
+            Assert.AreEqual("16428, \"Razer\\RzWizardPkg ; [Brackets=X]\"", data["DestinationDirs"]["Razer_Installer_CopyFilesWithBrackets"].PrimitiveValue);
         }
 
         [TestMethod()]

--- a/InfHelperTests/src/InfHelperTests.cs
+++ b/InfHelperTests/src/InfHelperTests.cs
@@ -72,13 +72,13 @@ namespace InfHelperTests
                 "Razer_CoInstaller_CopyFiles = 11\r\n" +
                 "Razer_Installer_CopyFiles = 16422,\"Razer\\RzWizardPkg\"\r\n" +
                 "Razer_Installer_CopyFilesWOW64 = 16426,\"Razer\\RzWizardPkg\"\r\n" +
-                "Razer_Installer_CopyFilesWithBrackets = 16428,\"Razer\\RzWizardPkg [Brackets]\"";
+                "Razer_Installer_CopyFilesWithBrackets = 16428,\"Razer\\RzWizardPkg [Brackets=X]\"";
             var helper = new InfUtil();
             var data = helper.Parse(formula);
             Assert.AreEqual("11", data["DestinationDirs"]["Razer_CoInstaller_CopyFiles"].PrimitiveValue);
             Assert.AreEqual("16422, \"Razer\\RzWizardPkg\"", data["DestinationDirs"]["Razer_Installer_CopyFiles"].PrimitiveValue);
             Assert.AreEqual("16426, \"Razer\\RzWizardPkg\"", data["DestinationDirs"]["Razer_Installer_CopyFilesWOW64"].PrimitiveValue);
-            Assert.AreEqual("16428, \"Razer\\RzWizardPkg [Brackets]\"", data["DestinationDirs"]["Razer_Installer_CopyFilesWithBrackets"].PrimitiveValue);
+            Assert.AreEqual("16428, \"Razer\\RzWizardPkg [Brackets=X]\"", data["DestinationDirs"]["Razer_Installer_CopyFilesWithBrackets"].PrimitiveValue);
         }
 
         [TestMethod()]

--- a/InfHelperTests/src/InfHelperTests.cs
+++ b/InfHelperTests/src/InfHelperTests.cs
@@ -68,12 +68,17 @@ namespace InfHelperTests
         public void PureValueParsingTest()
         {
             string formula =
-                "[DestinationDirs]\r\nRazer_CoInstaller_CopyFiles = 11\r\nRazer_Installer_CopyFiles = 16422,\"Razer\\RzWizardPkg\"\r\nRazer_Installer_CopyFilesWOW64 = 16426,\"Razer\\RzWizardPkg\"";
+                "[DestinationDirs]\r\n" + 
+                "Razer_CoInstaller_CopyFiles = 11\r\n" +
+                "Razer_Installer_CopyFiles = 16422,\"Razer\\RzWizardPkg\"\r\n" +
+                "Razer_Installer_CopyFilesWOW64 = 16426,\"Razer\\RzWizardPkg\"\r\n" +
+                "Razer_Installer_CopyFilesWithBrackets = 16428,\"Razer\\RzWizardPkg [Brackets]\"";
             var helper = new InfUtil();
             var data = helper.Parse(formula);
             Assert.AreEqual("11", data["DestinationDirs"]["Razer_CoInstaller_CopyFiles"].PrimitiveValue);
             Assert.AreEqual("16422, \"Razer\\RzWizardPkg\"", data["DestinationDirs"]["Razer_Installer_CopyFiles"].PrimitiveValue);
             Assert.AreEqual("16426, \"Razer\\RzWizardPkg\"", data["DestinationDirs"]["Razer_Installer_CopyFilesWOW64"].PrimitiveValue);
+            Assert.AreEqual("16428, \"Razer\\RzWizardPkg [Brackets]\"", data["DestinationDirs"]["Razer_Installer_CopyFilesWithBrackets"].PrimitiveValue);
         }
 
         [TestMethod()]


### PR DESCRIPTION
Hi, 

I was playing around with the InfHelper and had an issue parsing a Realtek HD Audio Driver INF file (the file in the PR). I analyized the issue and it was a result of ignoring Comments in the key/values section.

The (first) line causing the issue was:

    "Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA3969 ; Thinkbook Gen4+ 14"

It ends with a quotation character, because it's a 14 inch device. The current implementation parses the line and detects the start of a quotation at the end of the line and does not accept the following new line. This issue just made the true issue visible: Comments after a value are returned as part of the value. So I changed a unit test and added a comment at the end of the value without changing the expected value.