### PR TITLE
Provide null entries for empty parts when KeyValue parsing

### DIFF
--- a/InfHelper/src/Parsers/ContentParser.cs
+++ b/InfHelper/src/Parsers/ContentParser.cs
@@ -321,7 +321,7 @@ namespace InfHelper.Parsers
             switch (tokenBase.Type)
             {
                 case TokenType.ValueSeparator:
-                    ValueParsingComplete();
+                    ValueParsingComplete(allowNull: true);
                     break;
                 case TokenType.Letter:
                     keyTmpValue += tokenBase.Symbol;
@@ -363,9 +363,9 @@ namespace InfHelper.Parsers
             }
         }
 
-        protected void ValueParsingComplete(bool pure = false)
+        protected void ValueParsingComplete(bool pure = false, bool allowNull = false)
         {
-            if (!string.IsNullOrEmpty(keyTmpValue))
+            if (allowNull || !string.IsNullOrEmpty(keyTmpValue))
             {
                 KeyValue keyValue;
                 if (!pure)

--- a/InfHelperTests/src/InfHelperTests.cs
+++ b/InfHelperTests/src/InfHelperTests.cs
@@ -134,5 +134,17 @@ namespace InfHelperTests
             // info.Categories should contain [OEM URLS]
             Assert.IsTrue(info.Categories.Count(x => x.Name == "OEM URLS") == 1);
         }
+
+        [TestMethod()]
+        public void EmptySeparatorsAreNull()
+        {
+            var helper = new InfUtil();
+            var info = helper.ParseFile(Path.Combine(testFolder, "oem136.inf"));
+
+            var sourceDisksSection = info.Categories.FirstOrDefault(c => c.Name == "SourceDisksNames");
+
+            Assert.IsTrue(sourceDisksSection.Keys.First().KeyValues.Count == 4);
+            Assert.IsTrue(sourceDisksSection.Keys.First().KeyValues.Last().Value == "\\");
+        }
     }
 }


### PR DESCRIPTION
This will allow for reliable identification of values

### Goal
Closes #14

### Background
Some INF section entries have optional values. The current parsed INF object only returns sections that have a non-empty value. This makes it difficult to identify which optional sections have been skipped.

### Testing
Added a unit test

&nbsp;

Given the following INF entry:
```
[SourceDisksNames]
222=%DiskDescription%,,,\,flags
```

Before the change, the KeyValue entries would be: `[%DiskDescription%, \, flags]`

After the change, the entries would be: `[%DiskDescription%, null, null, \, flags]`

This helps in the situation in which I want to find the `path` entry, which is `\` in this case. Without the nulls, it is not possible to reliably get this section.
