### PR TITLE
Fix parsing of quoted keys

### DIFF
--- a/InfHelper/src/Parsers/ContentParser.cs
+++ b/InfHelper/src/Parsers/ContentParser.cs
@@ -207,9 +207,20 @@ namespace InfHelper.Parsers
                     keyTmpValue += tokenBase.Symbol;
                     break;
                 case TokenType.ValueMarker:
+                    if (!string.IsNullOrEmpty(currentKey.Id))
+                    {
+                        ValueParsingComplete(true);
+                        InitKeyValueParsing();
+                    }
+                    else
+                    {
+                        InitKeyIdParsing();
+                    }
+                    break;
                 case TokenType.NewLine:
                     ValueParsingComplete(true);
-                    InitKeyValueParsing();
+                    KeyParsingComplete();
+                    InitKeyIdParsing();
                     break;
                 default:
                     throw new InvalidTokenException("Invalid tokenBase found during comment parsing: " + tokenBase.Symbol);

--- a/InfHelperTests/src/InfHelperTests.cs
+++ b/InfHelperTests/src/InfHelperTests.cs
@@ -82,6 +82,16 @@ namespace InfHelperTests
         }
 
         [TestMethod()]
+        public void QuotedKeyParsingTest()
+        {
+            string formula =
+                "[AzaliaManufacturerID.NTamd64.10.0...15063]\r\n\"Realtek High Definition Audio\" = IntcAzAudModel, HDAUDIO\\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39F5 ; ThinkBook 16p NX ARH\r\n";
+            var helper = new InfUtil();
+            var data = helper.Parse(formula);
+            Assert.AreEqual("IntcAzAudModel, HDAUDIO\\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39F5", data["AzaliaManufacturerID.NTamd64.10.0...15063"]["Realtek High Definition Audio"].PrimitiveValue);
+        }
+
+        [TestMethod()]
         public void SearchMethdTest()
         {
             string formula =


### PR DESCRIPTION
### Goal
Closes #19 

### Background
Some INF files use keys with quote characters, e.g. `InfHelperTests/infs/oem160.inf`:
```ini
"Realtek High Definition Audio" = IntcAzAudModel, HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39F5 ; ThinkBook 16p NX ARH
```

Under the current implementation, the parser incorrectly parses the key as a value, ending up with a Key object like this:
```cs
[null] = {"\"Realtek High Definition Audio\"", "=IntcAzAudModel", "HDAUDIO\FUNC_01&VEN_10EC&DEV_0257&SUBSYS_17AA39F5"}
```

### Implementation
I added a check to the closing quote handler, which returns to key ID parsing if the currently processed key does not have one yet. I also made sure the key parsing is finished upon encountering a quoted value terminated by a newline (#16)

### Testing
I added a new `QuotedKeyParsingTest` test that checks for this.
